### PR TITLE
1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bbPress Permalinks with ID
+# Permalinks with ID for bbPress
 
 This plugin transforms default bbPress permalinks (URLs) that use slugs into permalinks that use numeric IDs.
 

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Transforms default bbPress permalinks (URLs) that use slugs into permalinks that use numeric IDs.
  * Author: Nicolas Korobochkin
  * Author URI: https://korobochkin.wordpress.com/
- * Version: 1.0.6
+ * Version: 1.0.7
  * Text Domain: bbpress-permalinks-with-id
  * Requires at least: 4.1
  * Tested up to: 6.8

--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@
  * Author URI: https://korobochkin.wordpress.com/
  * Version: 1.0.6
  * Text Domain: bbpress-permalinks-with-id
- * Requires at least: 4.1.1
+ * Requires at least: 4.1
  * Tested up to: 6.8
  * Requires PHP: 5.6
  * Requires Plugins: bbpress

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: bbPress Permalinks with ID
+ * Plugin Name: Permalinks with ID for bbPress
  * Plugin URI: https://github.com/korobochkin/bbpress-permalinks-with-id
  * Description: Transforms default bbPress permalinks (URLs) that use slugs into permalinks that use numeric IDs.
  * Author: Nicolas Korobochkin

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Permalinks with ID for bbPress ===
 Contributors: korobochkin
 Tags: bbpress, permalink, url, rewrite rule
-Requires at least: 4.1.1
+Requires at least: 4.1
 Tested up to: 6.8
 Stable tag: 1.0.6
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: korobochkin
 Tags: bbpress, permalink, url, rewrite rule
 Requires at least: 4.1
 Tested up to: 6.8
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -70,6 +70,10 @@ The plugin undergoes manual testing with the latest WordPress and bbPress versio
 * Shorter, cleaner URLs that are easier to share and remember.
 
 == Changelog ==
+
+= 1.0.7 =
+
+No code changes. The plugin was renamed and the "Requires at least" version was updated to comply with new WordPress.org policies.
 
 = 1.0.6 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== bbPress Permalinks with ID ===
+=== Permalinks with ID for bbPress ===
 Contributors: korobochkin
 Tags: bbpress, permalink, url, rewrite rule
 Requires at least: 4.1.1


### PR DESCRIPTION
No code changes. The plugin was renamed and the "Requires at least" version was updated to comply with new WordPress.org policies.