### PR TITLE
Application Tests. Edit forums

### DIFF
--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -23,10 +23,17 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     {
         $crawler = $this->requestEditPage($browser, $forum);
 
-        $this->_testForumEditPage($browser, $forum, $crawler);
+        $this->testForumEditPage($browser, $forum, $crawler);
     }
 
-    protected function _testForumEditPage(HttpBrowser $browser, Forum $forum, Crawler $crawler): void
+    private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
+    {
+        $browser->followRedirects(false);
+
+        return $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+    }
+
+    private function testForumEditPage(HttpBrowser $browser, Forum $forum, Crawler $crawler): void
     {
         $this->assertPageStatusIs200($browser->getResponse());
         $this->assertPageTitleEquals($forum->getTitle(), $crawler);
@@ -38,7 +45,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertForumEditFormHasSubmit($crawler);
     }
 
-    protected function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void
+    private function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void
     {
         $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_forum_id"]');
 
@@ -46,7 +53,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertEquals($forum->getId(), $input->attr('value'));
     }
 
-    protected function assertForumEditFormHasTitle(Forum $forum, Crawler $crawler): void
+    private function assertForumEditFormHasTitle(Forum $forum, Crawler $crawler): void
     {
         $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@name="bbp_forum_title"]');
 
@@ -54,7 +61,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertEquals($forum->getTitle(), $input->attr('value'));
     }
 
-    protected function assertForumEditFormHasContent(Forum $forum, Crawler $crawler): void
+    private function assertForumEditFormHasContent(Forum $forum, Crawler $crawler): void
     {
         $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//textarea[@name="bbp_forum_content"]');
 
@@ -62,18 +69,11 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertEquals($forum->getContent(), $input->innerText());
     }
 
-    protected function assertForumEditFormHasSubmit(Crawler $crawler): void
+    private function assertForumEditFormHasSubmit(Crawler $crawler): void
     {
         $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//button[@name="bbp_forum_submit"]');
 
         $this->assertCount(1, $input);
         $this->assertEquals('Submit', $input->text());
-    }
-
-    private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
-    {
-        $browser->followRedirects(false);
-
-        return $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
     }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -18,15 +18,23 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertEditPageRedirected($browser, $forum);
     }
 
-    protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum, Forum $newForum): void
+    protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum): void
     {
-        // Original content
-        $this->testForumEditPage($browser, $forum, $crawler = $this->requestEditPage($browser, $forum));
+        $crawler = $this->requestEditPage($browser, $forum);
+        $this->testForumEditPage($browser, $forum, $crawler);
+    }
 
-        // Edit content
+    protected function _testForumSubmitEditAsAdmin(HttpBrowser $browser, Forum $forum, Forum $newForum): void
+    {
+        $crawler = $this->requestEditPage($browser, $forum);
+
         $this->submitForumEditForm($browser, $crawler, $newForum);
+
         $this->assertEditPageRedirected($browser, $forum);
-        $this->testForumEditPage($browser, $newForum, $crawler2 = $this->requestEditPage($browser, $forum));
+
+        $crawler2 = $this->requestEditPage($browser, $forum);
+
+        $this->testForumEditPage($browser, $newForum, $crawler2);
 
         // Rollback to the original content
         $this->submitForumEditForm($browser, $crawler2, $forum);

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -13,8 +13,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
 {
     protected function _testForumEditAsGuest(HttpBrowser $browser, Forum $forum): void
     {
-        $browser->followRedirects(false);
-        $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+        $this->requestEditPage($browser, $forum);
 
         $this->assertIsRedirect($browser->getResponse());
         $this->assertLocation($this->useNumericPermalinksHTML ? $forum->getNumericPermalink() : $forum->getSamplePermalink(), $browser->getResponse());
@@ -22,8 +21,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
 
     protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum): void
     {
-        $browser->followRedirects(false);
-        $crawler = $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+        $crawler = $this->requestEditPage($browser, $forum);
 
         $this->_testForumEditPage($browser, $forum, $crawler);
     }
@@ -40,6 +38,14 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertForumEditFormHasSubmit($crawler);
     }
 
+    protected function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_forum_id"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($forum->getId(), $input->attr('value'));
+    }
+
     protected function assertForumEditFormHasTitle(Forum $forum, Crawler $crawler): void
     {
         $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@name="bbp_forum_title"]');
@@ -54,14 +60,6 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
 
         $this->assertCount(1, $input);
         $this->assertEquals($forum->getContent(), $input->innerText());
-    }
-
-    protected function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void
-    {
-        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_forum_id"]');
-
-        $this->assertCount(1, $input);
-        $this->assertEquals($forum->getId(), $input->attr('value'));
     }
 
     protected function assertForumEditFormHasSubmit(Crawler $crawler): void

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
@@ -25,7 +26,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->testForumEditPage($browser, $forum, $crawler);
 
         // Submit form
-        $newForum = $this->cloneAndEditForum($forum);
+        $newForum = PostUtilities::copyAndEditTitleAndContent($forum);
         $browser->submit(
             $this->findForumEditForm($crawler),
             [
@@ -109,14 +110,5 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     private function findForumEditForm(Crawler $crawler): Form
     {
         return $crawler->filterXPath('//body//div[@id="page"]//div[contains(@class, "entry-content")]//form[@id="new-post"]')->form();
-    }
-
-    private function cloneAndEditForum(Forum $forum): Forum
-    {
-        $editedForum = clone $forum;
-        $editedForum->setTitle(implode(' ', ['EDITED', $forum->getTitle(), 'EDITED']));
-        $editedForum->setContent(implode(' ', ['EDITED', $forum->getContent(), 'EDITED']));
-
-        return $editedForum;
     }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -14,9 +14,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     protected function _testForumEditAsGuest(HttpBrowser $browser, Forum $forum): void
     {
         $this->requestEditPage($browser, $forum);
-
-        $this->assertIsRedirect($browser->getResponse());
-        $this->assertLocation($this->useNumericPermalinksHTML ? $forum->getNumericPermalink() : $forum->getSamplePermalink(), $browser->getResponse());
+        $this->assertEditPageRedirected($browser, $forum);
     }
 
     protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum): void
@@ -43,6 +41,12 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertForumEditFormHasTitle($forum, $crawler);
         $this->assertForumEditFormHasContent($forum, $crawler);
         $this->assertForumEditFormHasSubmit($crawler);
+    }
+
+    private function assertEditPageRedirected(HttpBrowser $browser, Forum $forum): void
+    {
+        $this->assertIsRedirect($browser->getResponse());
+        $this->assertLocation($this->useNumericPermalinksHTML ? $forum->getNumericPermalink() : $forum->getSamplePermalink(), $browser->getResponse());
     }
 
     private function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
@@ -19,14 +18,14 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertEditPageRedirected($browser, $forum);
     }
 
-    protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum): void
+    protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum, Forum $newForum): void
     {
+        // Original content
         $crawler = $this->requestEditPage($browser, $forum);
 
         $this->testForumEditPage($browser, $forum, $crawler);
 
-        // Submit form
-        $newForum = PostUtilities::copyAndEditTitleAndContent($forum);
+        // Edit content
         $browser->submit(
             $this->findForumEditForm($crawler),
             [
@@ -35,10 +34,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
             ],
         );
         $this->assertEditPageRedirected($browser, $forum);
-
-        // Check that form was submitted
-        $crawler2 = $this->requestEditPage($browser, $forum);
-        $this->testForumEditPage($browser, $newForum, $crawler2);
+        $this->testForumEditPage($browser, $newForum, $crawler2 = $this->requestEditPage($browser, $forum));
 
         // Rollback to the original content
         $browser->submit(

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -21,29 +21,15 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum, Forum $newForum): void
     {
         // Original content
-        $crawler = $this->requestEditPage($browser, $forum);
-
-        $this->testForumEditPage($browser, $forum, $crawler);
+        $this->testForumEditPage($browser, $forum, $crawler = $this->requestEditPage($browser, $forum));
 
         // Edit content
-        $browser->submit(
-            $this->findForumEditForm($crawler),
-            [
-                'bbp_forum_title' => $newForum->getTitle(),
-                'bbp_forum_content' => $newForum->getContent(),
-            ],
-        );
+        $this->submitForumEditForm($browser, $crawler, $newForum);
         $this->assertEditPageRedirected($browser, $forum);
         $this->testForumEditPage($browser, $newForum, $crawler2 = $this->requestEditPage($browser, $forum));
 
         // Rollback to the original content
-        $browser->submit(
-            $this->findForumEditForm($crawler2),
-            [
-                'bbp_forum_title' => $forum->getTitle(),
-                'bbp_forum_content' => $forum->getContent(),
-            ],
-        );
+        $this->submitForumEditForm($browser, $crawler2, $forum);
     }
 
     private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
@@ -106,5 +92,16 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     private function findForumEditForm(Crawler $crawler): Form
     {
         return $crawler->filterXPath('//body//div[@id="page"]//div[contains(@class, "entry-content")]//form[@id="new-post"]')->form();
+    }
+
+    private function submitForumEditForm(HttpBrowser $browser, Crawler $crawler, Forum $forum): void
+    {
+        $browser->submit(
+            $this->findForumEditForm($crawler),
+            [
+                'bbp_forum_title' => $forum->getTitle(),
+                'bbp_forum_content' => $forum->getContent(),
+            ],
+        );
     }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
+use Symfony\Component\BrowserKit\HttpBrowser;
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class AbstractForumEditTest extends AbstractHttpTestCase
+{
+    protected function _testForumEditAsGuest(HttpBrowser $browser, Forum $forum): void
+    {
+        $browser->followRedirects(false);
+        $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+
+        $this->assertIsRedirect($browser->getResponse());
+        $this->assertLocation($this->useNumericPermalinksHTML ? $forum->getNumericPermalink() : $forum->getSamplePermalink(), $browser->getResponse());
+    }
+
+    protected function _testForumEditAsAdmin(HttpBrowser $browser, Forum $forum): void
+    {
+        $browser->followRedirects(false);
+        $crawler = $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+
+        $this->_testForumEditPage($browser, $forum, $crawler);
+    }
+
+    protected function _testForumEditPage(HttpBrowser $browser, Forum $forum, Crawler $crawler): void
+    {
+        $this->assertPageStatusIs200($browser->getResponse());
+        $this->assertPageTitleEquals($forum->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
+
+        $this->assertForumEditFormHasId($forum, $crawler);
+        $this->assertForumEditFormHasTitle($forum, $crawler);
+        $this->assertForumEditFormHasContent($forum, $crawler);
+        $this->assertForumEditFormHasSubmit($crawler);
+    }
+
+    protected function assertForumEditFormHasTitle(Forum $forum, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@name="bbp_forum_title"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($forum->getTitle(), $input->attr('value'));
+    }
+
+    protected function assertForumEditFormHasContent(Forum $forum, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//textarea[@name="bbp_forum_content"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($forum->getContent(), $input->innerText());
+    }
+
+    protected function assertForumEditFormHasId(Forum $forum, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_forum_id"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($forum->getId(), $input->attr('value'));
+    }
+
+    protected function assertForumEditFormHasSubmit(Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//button[@name="bbp_forum_submit"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals('Submit', $input->text());
+    }
+}

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -8,6 +8,7 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\For
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Form;
 
 abstract class AbstractForumEditTest extends AbstractHttpTestCase
 {
@@ -22,6 +23,30 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $crawler = $this->requestEditPage($browser, $forum);
 
         $this->testForumEditPage($browser, $forum, $crawler);
+
+        // Submit form
+        $newForum = $this->cloneAndEditForum($forum);
+        $browser->submit(
+            $this->findForumEditForm($crawler),
+            [
+                'bbp_forum_title' => $newForum->getTitle(),
+                'bbp_forum_content' => $newForum->getContent(),
+            ],
+        );
+        $this->assertEditPageRedirected($browser, $forum);
+
+        // Check that form was submitted
+        $crawler2 = $this->requestEditPage($browser, $forum);
+        $this->testForumEditPage($browser, $newForum, $crawler2);
+
+        // Rollback to the original content
+        $browser->submit(
+            $this->findForumEditForm($crawler2),
+            [
+                'bbp_forum_title' => $forum->getTitle(),
+                'bbp_forum_content' => $forum->getContent(),
+            ],
+        );
     }
 
     private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
@@ -79,5 +104,19 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
 
         $this->assertCount(1, $input);
         $this->assertEquals('Submit', $input->text());
+    }
+
+    private function findForumEditForm(Crawler $crawler): Form
+    {
+        return $crawler->filterXPath('//body//div[@id="page"]//div[contains(@class, "entry-content")]//form[@id="new-post"]')->form();
+    }
+
+    private function cloneAndEditForum(Forum $forum): Forum
+    {
+        $editedForum = clone $forum;
+        $editedForum->setTitle(implode(' ', ['EDITED', $forum->getTitle(), 'EDITED']));
+        $editedForum->setContent(implode(' ', ['EDITED', $forum->getContent(), 'EDITED']));
+
+        return $editedForum;
     }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -69,4 +69,11 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->assertCount(1, $input);
         $this->assertEquals('Submit', $input->text());
     }
+
+    private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
+    {
+        $browser->followRedirects(false);
+
+        return $browser->request('GET', URL::editPermalink($forum, $this->useNumericPermalinksRequests));
+    }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser\FrontendUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
 use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\DomCrawler\Form;
 
 abstract class AbstractForumEditTest extends AbstractHttpTestCase
 {
@@ -28,7 +28,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
     {
         $crawler = $this->requestEditPage($browser, $forum);
 
-        $this->submitForumEditForm($browser, $crawler, $newForum);
+        FrontendUtilities::submitEditForm($browser, $crawler, $newForum);
 
         $this->assertEditPageRedirected($browser, $forum);
 
@@ -37,7 +37,7 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
         $this->testForumEditPage($browser, $newForum, $crawler2);
 
         // Rollback to the original content
-        $this->submitForumEditForm($browser, $crawler2, $forum);
+        FrontendUtilities::submitEditForm($browser, $crawler2, $forum);
     }
 
     private function requestEditPage(HttpBrowser $browser, Forum $forum): Crawler
@@ -95,21 +95,5 @@ abstract class AbstractForumEditTest extends AbstractHttpTestCase
 
         $this->assertCount(1, $input);
         $this->assertEquals('Submit', $input->text());
-    }
-
-    private function findForumEditForm(Crawler $crawler): Form
-    {
-        return $crawler->filterXPath('//body//div[@id="page"]//div[contains(@class, "entry-content")]//form[@id="new-post"]')->form();
-    }
-
-    private function submitForumEditForm(HttpBrowser $browser, Crawler $crawler, Forum $forum): void
-    {
-        $browser->submit(
-            $this->findForumEditForm($crawler),
-            [
-                'bbp_forum_title' => $forum->getTitle(),
-                'bbp_forum_content' => $forum->getContent(),
-            ],
-        );
     }
 }

--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -54,6 +54,11 @@ abstract class AbstractHttpTestCase extends TestCase
         $this->assertThat($response->getStatusCode(), $this->logicalAnd($this->greaterThanOrEqual(300), $this->lessThan(400)));
     }
 
+    protected function assertLocation(string $expectedLocation, Response $response): void
+    {
+        $this->assertEquals($expectedLocation, $response->getHeader('location'));
+    }
+
     protected function assertSampleLinkIsOk(AbstractPost $post): void
     {
         $this->assertThat(

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -7,7 +7,6 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProvider
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Random;
 
 class ForumDataProvider
@@ -37,13 +36,6 @@ class ForumDataProvider
         self::prepareInstance();
 
         return self::$instance->forumsGenerator();
-    }
-
-    public static function getForumsForEdit(): \Generator
-    {
-        self::prepareInstance();
-
-        return self::$instance->forumsGeneratorForEdit();
     }
 
     public static function getTopicsPaged(): \Generator
@@ -166,16 +158,6 @@ class ForumDataProvider
     {
         foreach ($this->data as $i => [$forum]) {
             yield $i => [$forum];
-        }
-    }
-
-    /**
-     * @return \Generator<int, array{Forum, Forum}, mixed, void>
-     */
-    private function forumsGeneratorForEdit(): \Generator
-    {
-        foreach ($this->data as $i => [$forum]) {
-            yield $i => [$forum, PostUtilities::copyAndEditTitleAndContent($forum)];
         }
     }
 

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -7,6 +7,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProvider
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Random;
 
 class ForumDataProvider
@@ -36,6 +37,13 @@ class ForumDataProvider
         self::prepareInstance();
 
         return self::$instance->forumsGenerator();
+    }
+
+    public static function getForumsForEdit(): \Generator
+    {
+        self::prepareInstance();
+
+        return self::$instance->forumsGeneratorForEdit();
     }
 
     public static function getTopicsPaged(): \Generator
@@ -158,6 +166,16 @@ class ForumDataProvider
     {
         foreach ($this->data as $i => [$forum]) {
             yield $i => [$forum];
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{Forum, Forum}, mixed, void>
+     */
+    private function forumsGeneratorForEdit(): \Generator
+    {
+        foreach ($this->data as $i => [$forum]) {
+            yield $i => [$forum, PostUtilities::copyAndEditTitleAndContent($forum)];
         }
     }
 

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
@@ -29,9 +29,16 @@ class ForumEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
-    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+    }
+
+    #[Attributes\Depends('testForumEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
+    public function testForumSubmitEditAsAdmin(Forum $forum, Forum $newForum): void
+    {
+        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, $newForum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
@@ -7,6 +7,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\Pl
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractForumEditTest;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use PHPUnit\Framework\Attributes;
 
 /**
@@ -36,9 +37,9 @@ class ForumEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsAdmin')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
-    public function testForumSubmitEditAsAdmin(Forum $forum, Forum $newForum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumSubmitEditAsAdmin(Forum $forum): void
     {
-        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, $newForum);
+        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, PostUtilities::copyAndEditTitleAndContent($forum));
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractForumEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ForumEditTest extends AbstractForumEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(ForumNumericPagedTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsGuest(Forum $forum): void
+    {
+        $this->_testForumEditAsGuest($this->browsers->guest, $forum);
+    }
+
+    #[Attributes\Depends('testForumEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
+    {
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumEditTest.php
@@ -29,9 +29,9 @@ class ForumEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
-    public function testForumEditAsAdmin(Forum $forum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
+    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
@@ -30,9 +30,9 @@ class ForumNumericEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
-    public function testForumEditAsAdmin(Forum $forum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
+    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractForumEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ForumNumericEditTest extends AbstractForumEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksRequests = true;
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(ForumEditTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsGuest(Forum $forum): void
+    {
+        $this->_testForumEditAsGuest($this->browsers->guest, $forum);
+    }
+
+    #[Attributes\Depends('testForumEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
+    {
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
@@ -7,6 +7,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\Pl
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractForumEditTest;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
 use PHPUnit\Framework\Attributes;
 
 /**
@@ -37,9 +38,9 @@ class ForumNumericEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsAdmin')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
-    public function testForumSubmitEditAsAdmin(Forum $forum, Forum $newForum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumSubmitEditAsAdmin(Forum $forum): void
     {
-        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, $newForum);
+        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, PostUtilities::copyAndEditTitleAndContent($forum));
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ForumNumericEditTest.php
@@ -30,9 +30,16 @@ class ForumNumericEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
-    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+    }
+
+    #[Attributes\Depends('testForumEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
+    public function testForumSubmitEditAsAdmin(Forum $forum, Forum $newForum): void
+    {
+        $this->_testForumSubmitEditAsAdmin($this->browsers->admin, $forum, $newForum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/TopicTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/TopicTest.php
@@ -22,7 +22,7 @@ class TopicTest extends AbstractTopicTest
         $this->useNumericPermalinksHTML = true;
     }
 
-    #[Attributes\DependsOnClass(ForumNumericPagedTest::class)]
+    #[Attributes\DependsOnClass(ForumNumericEditTest::class)]
     #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
     public function testTopicAsGuest(Forum $forum, Topic $topic): void
     {

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsNotActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractForumEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ForumEditTest extends AbstractForumEditTest
+{
+    #[Attributes\DependsOnClass(ForumPagedTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsGuest(Forum $forum): void
+    {
+        $this->_testForumEditAsGuest($this->browsers->guest, $forum);
+    }
+
+    #[Attributes\Depends('testForumEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
+    {
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
@@ -23,9 +23,9 @@ class ForumEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
-    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
+    public function testForumEditAsAdmin(Forum $forum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ForumEditTest.php
@@ -23,9 +23,9 @@ class ForumEditTest extends AbstractForumEditTest
     }
 
     #[Attributes\Depends('testForumEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForums')]
-    public function testForumEditAsAdmin(Forum $forum): void
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getForumsForEdit')]
+    public function testForumEditAsAdmin(Forum $forum, Forum $newForum): void
     {
-        $this->_testForumEditAsAdmin($this->browsers->admin, $forum);
+        $this->_testForumEditAsAdmin($this->browsers->admin, $forum, $newForum);
     }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyTest.php
@@ -37,7 +37,7 @@ class ReplyTest extends AbstractReplyTest
         }
     }
 
-    #[Attributes\DependsOnClass(ForumPagedTest::class)]
+    #[Attributes\DependsOnClass(ForumEditTest::class)]
     #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
     public function testCreateReply(Forum $forum, Topic $topic, Reply $reply): void
     {

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+use Symfony\Component\BrowserKit\HttpBrowser;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Form;
+
+class FrontendUtilities
+{
+    public static function submitEditForm(HttpBrowser $browser, Crawler $crawler, AbstractPost $post): void
+    {
+        $browser->submit(
+            static::findEditForm($crawler),
+            [
+                'bbp_forum_title' => $post->getTitle(),
+                'bbp_forum_content' => $post->getContent(),
+            ],
+        );
+    }
+
+    private static function findEditForm(Crawler $crawler): Form
+    {
+        return $crawler->filterXPath('//body//div[@id="page"]//div[contains(@class, "entry-content")]//form[@id="new-post"]')->form();
+    }
+}

--- a/.github/tests/application/tests/Utilities/PostUtilities.php
+++ b/.github/tests/application/tests/Utilities/PostUtilities.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+
+class PostUtilities
+{
+    /**
+     * @template Type of AbstractPost
+     *
+     * @param Type $post
+     *
+     * @return Type
+     */
+    public static function copyAndEditTitleAndContent(AbstractPost $post): AbstractPost
+    {
+        $editedPost = clone $post;
+
+        $editTitleString = implode('_', ['EDIT', Random::positiveInteger()]);
+        $editContentString = implode('_', ['EDIT', Random::positiveInteger()]);
+
+        $editedPost->setTitle(implode(' ', [$editTitleString, $post->getTitle(), $editTitleString]));
+        $editedPost->setContent(implode(' ', [$editContentString, $post->getContent(), $editContentString]));
+
+        return $editedPost;
+    }
+}

--- a/.github/tests/application/tests/Utilities/URL.php
+++ b/.github/tests/application/tests/Utilities/URL.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 
 class URL
@@ -15,6 +16,17 @@ class URL
             $useNumericPermalinks ? $post->getNumericPermalink() : $post->getSamplePermalink(),
             $page,
         );
+    }
+
+    public static function editPermalink(Forum|Reply|Topic $post, bool $useNumericPermalinks): string
+    {
+        $permalink = $useNumericPermalinks ? $post->getNumericPermalink() : $post->getSamplePermalink();
+
+        if (!str_ends_with($permalink, '/')) {
+            throw new \LogicException('Invalid permalink format');
+        }
+
+        return $permalink.'edit/';
     }
 
     private static function paged(string $permalink, int $page): string


### PR DESCRIPTION
Added a few new tests for `edit` forum pages in bbPress. The tests include validation for requesting the page, ensuring it has the necessary elements, and also submitting a form for editing the forum title and content.