### PR TITLE
Application Tests. Disable `gzip` encoding in HTTP responses

### DIFF
--- a/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumEditTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser\FrontendUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
-use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractForumEditTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Abstracts/AbstractForumPagedTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumPagedTest.php
@@ -6,8 +6,8 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
-use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractForumPagedTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Abstracts/AbstractForumTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
-use Symfony\Component\BrowserKit\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractForumTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Abstracts/AbstractForumsPageTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractForumsPageTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\ForumsPage;
-use Symfony\Component\BrowserKit\HttpBrowser;
 
 abstract class AbstractForumsPageTest extends AbstractHttpTestCase
 {

--- a/.github/tests/application/tests/Abstracts/AbstractReplyTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractReplyTest.php
@@ -7,7 +7,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
-use Symfony\Component\BrowserKit\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractReplyTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Abstracts/AbstractTopicPagedTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractTopicPagedTest.php
@@ -7,8 +7,8 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
-use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractTopicPagedTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Abstracts/AbstractTopicTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractTopicTest.php
@@ -6,7 +6,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
-use Symfony\Component\BrowserKit\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 abstract class AbstractTopicTest extends AbstractHttpTestCase

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -10,7 +10,6 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Pag
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Status;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
-use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 
 final class BrowserActions

--- a/.github/tests/application/tests/Services/BrowsersService.php
+++ b/.github/tests/application/tests/Services/BrowsersService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services;
 
-use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\HttpClient\HttpClient;
 
 class BrowsersService

--- a/.github/tests/application/tests/Services/HttpBrowser.php
+++ b/.github/tests/application/tests/Services/HttpBrowser.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services;
+
+use Symfony\Component\BrowserKit\Request;
+
+class HttpBrowser extends \Symfony\Component\BrowserKit\HttpBrowser
+{
+    protected function getHeaders(Request $request): array
+    {
+        $headers = parent::getHeaders($request);
+
+        // Disallows gzip in responses.
+        $headers['accept-encoding'] = 'identity';
+
+        return $headers;
+    }
+}

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
-use Symfony\Component\BrowserKit\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 


### PR DESCRIPTION
HTTP responses from the `wordpress` container contain gzipped content. I think it might be not necessary because all requests and responses are travel in the same network and on a single physical machine during tests. With this little header added to all requests, responses now don't have `content-encoding = gzip` header.