### PR TITLE
Application Tests. Edit topics

### DIFF
--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\PostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\BrowsersService;
@@ -59,7 +59,7 @@ abstract class AbstractHttpTestCase extends TestCase
         $this->assertEquals($expectedLocation, $response->getHeader('location'));
     }
 
-    protected function assertSampleLinkIsOk(AbstractPost $post): void
+    protected function assertSampleLinkIsOk(PostInterface $post): void
     {
         $this->assertThat(
             $post->getSamplePermalink(),

--- a/.github/tests/application/tests/Abstracts/AbstractTopicEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractTopicEditTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class AbstractTopicEditTest extends AbstractHttpTestCase
+{
+    protected function _testTopicEditAsGuest(HttpBrowser $browser, Forum $forum, Topic $topic): void
+    {
+        $this->requestEditPage($browser, $topic);
+        $this->assertEditPageRedirected($browser, $topic);
+    }
+
+    protected function _testTopicEditAsAdmin(HttpBrowser $browser, Forum $forum, Topic $topic): void
+    {
+        $crawler = $this->requestEditPage($browser, $topic);
+        $this->testTopicEditPage($browser, $forum, $topic, $crawler);
+    }
+
+    private function requestEditPage(HttpBrowser $browser, Topic $topic): Crawler
+    {
+        $browser->followRedirects(false);
+
+        return $browser->request('GET', URL::editPermalink($topic, $this->useNumericPermalinksRequests));
+    }
+
+    private function testTopicEditPage(HttpBrowser $browser, Forum $forum, Topic $topic, Crawler $crawler): void
+    {
+        $this->assertPageStatusIs200($browser->getResponse());
+        $this->assertPageTitleEquals($topic->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($topic->getTitle(), $crawler);
+
+        $this->assertTopicEditFormHasForumId($forum, $crawler);
+        $this->assertTopicEditFormHasId($topic, $crawler);
+        $this->assertTopicEditFormHasStick($crawler);
+        $this->assertTopicEditFormHasTitle($topic, $crawler);
+        $this->assertTopicEditFormHasContent($topic, $crawler);
+        $this->assertTopicEditFormHasSubmit($crawler);
+    }
+
+    private function assertEditPageRedirected(HttpBrowser $browser, Topic $topic): void
+    {
+        $this->assertIsRedirect($browser->getResponse());
+        $this->assertLocation($this->useNumericPermalinksHTML ? $topic->getNumericPermalink() : $topic->getSamplePermalink(), $browser->getResponse());
+    }
+
+    private function assertTopicEditFormHasForumId(Forum $forum, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//select[@name="bbp_forum_id"]/option[@selected="selected"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($forum->getId(), $input->attr('value'));
+    }
+
+    private function assertTopicEditFormHasId(Topic $topic, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_topic_id"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($topic->getId(), $input->attr('value'));
+    }
+
+    private function assertTopicEditFormHasStick(Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//select[@name="bbp_stick_topic"]/option[@selected="selected"]');
+        $this->assertCount(1, $input);
+        $this->assertEquals('unstick', $input->attr('value'));
+    }
+
+    private function assertTopicEditFormHasTitle(Topic $topic, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@name="bbp_topic_title"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($topic->getTitle(), $input->attr('value'));
+    }
+
+    private function assertTopicEditFormHasContent(Topic $topic, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//textarea[@name="bbp_topic_content"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($topic->getContent(), $input->innerText());
+    }
+
+    private function assertTopicEditFormHasSubmit(Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//button[@name="bbp_topic_submit"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals('Submit', $input->text());
+    }
+}

--- a/.github/tests/application/tests/Abstracts/AbstractTopicEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractTopicEditTest.php
@@ -7,6 +7,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser\FrontendUtilities;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -22,6 +23,22 @@ abstract class AbstractTopicEditTest extends AbstractHttpTestCase
     {
         $crawler = $this->requestEditPage($browser, $topic);
         $this->testTopicEditPage($browser, $forum, $topic, $crawler);
+    }
+
+    protected function _testTopicSubmitEditAsAdmin(HttpBrowser $browser, Forum $forum, Topic $topic, Topic $newTopic): void
+    {
+        $crawler = $this->requestEditPage($browser, $topic);
+
+        FrontendUtilities::submitEditForm($browser, $crawler, $newTopic);
+
+        $this->assertEditPageRedirected($browser, $topic);
+
+        $crawler2 = $this->requestEditPage($browser, $topic);
+
+        $this->testTopicEditPage($browser, $forum, $newTopic, $crawler2);
+
+        // Rollback to the original content
+        FrontendUtilities::submitEditForm($browser, $crawler2, $topic);
     }
 
     private function requestEditPage(HttpBrowser $browser, Topic $topic): Crawler

--- a/.github/tests/application/tests/Entities/Posts/AbstractPost.php
+++ b/.github/tests/application/tests/Entities/Posts/AbstractPost.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts;
 
-abstract class AbstractPost
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\PostInterface;
+
+abstract class AbstractPost implements PostInterface
 {
     private int $id;
 

--- a/.github/tests/application/tests/Entities/Posts/Forum.php
+++ b/.github/tests/application/tests/Entities/Posts/Forum.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts;
 
-class Forum extends AbstractPost
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
+
+class Forum extends AbstractPost implements BbPressPostInterface
 {
     public function getType(): Type
     {

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/BbPressPostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/BbPressPostInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces;
+
+interface BbPressPostInterface extends PostInterface {}

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Status;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Type;
+
+interface PostInterface
+{
+    public function getId(): int;
+
+    public function setId(int $id): self;
+
+    public function getType(): Type;
+
+    public function getStatus(): Status;
+
+    public function setStatus(Status $status): self;
+
+    public function getTitle(): string;
+
+    public function setTitle(string $title): self;
+
+    public function getContent(): string;
+
+    public function setContent(string $content): self;
+
+    public function getName(): string;
+
+    public function setName(string $name): self;
+
+    public function getAuthorId(): int;
+
+    public function setAuthorId(int $authorId): self;
+
+    public function getSamplePermalink(): string;
+
+    public function setSamplePermalink(string $samplePermalink): self;
+
+    public function getNumericPermalink(): string;
+}

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/WordPressPostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/WordPressPostInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces;
+
+interface WordPressPostInterface extends PostInterface {}

--- a/.github/tests/application/tests/Entities/Posts/Page.php
+++ b/.github/tests/application/tests/Entities/Posts/Page.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts;
 
-class Page extends AbstractPost
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\WordPressPostInterface;
+
+class Page extends AbstractPost implements WordPressPostInterface
 {
     public function getType(): Type
     {

--- a/.github/tests/application/tests/Entities/Posts/Reply.php
+++ b/.github/tests/application/tests/Entities/Posts/Reply.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts;
 
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Traits\ParentForumIdTrait;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Traits\ParentTopicIdTrait;
 
-class Reply extends AbstractPost
+class Reply extends AbstractPost implements BbPressPostInterface
 {
     use ParentForumIdTrait;
     use ParentTopicIdTrait;

--- a/.github/tests/application/tests/Entities/Posts/Topic.php
+++ b/.github/tests/application/tests/Entities/Posts/Topic.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts;
 
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Traits\ParentForumIdTrait;
 
-class Topic extends AbstractPost
+class Topic extends AbstractPost implements BbPressPostInterface
 {
     use ParentForumIdTrait;
 

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services;
 
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\PostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Page;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Status;
@@ -65,7 +66,7 @@ final class BrowserActions
         );
     }
 
-    private static function createBbPressPostTypes(HttpBrowser $browser, Forum|Reply|Topic $post): Crawler
+    private static function createBbPressPostTypes(HttpBrowser $browser, BbPressPostInterface $post): Crawler
     {
         $crawler = self::requestPostNewPage($browser, $post);
 
@@ -98,7 +99,7 @@ final class BrowserActions
         return $savedPostCrawler;
     }
 
-    private static function requestPostNewPage(HttpBrowser $browser, AbstractPost $post): Crawler
+    private static function requestPostNewPage(HttpBrowser $browser, PostInterface $post): Crawler
     {
         return $browser->request('GET', '/wp-admin/post-new.php?post_type='.$post->getType()->value);
     }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyTest.php
@@ -23,7 +23,7 @@ class ReplyTest extends AbstractReplyTest
         $this->useNumericPermalinksHTML = true;
     }
 
-    #[Attributes\DependsOnClass(TopicNumericPagedTest::class)]
+    #[Attributes\DependsOnClass(TopicEditTest::class)]
     #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
     public function testReplyAsGuest(Forum $forum, Topic $topic, Reply $reply): void
     {

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyTest.php
@@ -23,7 +23,7 @@ class ReplyTest extends AbstractReplyTest
         $this->useNumericPermalinksHTML = true;
     }
 
-    #[Attributes\DependsOnClass(TopicEditTest::class)]
+    #[Attributes\DependsOnClass(TopicNumericEditTest::class)]
     #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
     public function testReplyAsGuest(Forum $forum, Topic $topic, Reply $reply): void
     {

--- a/.github/tests/application/tests/TestCases/PluginIsActive/TopicEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/TopicEditTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractTopicEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class TopicEditTest extends AbstractTopicEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(TopicNumericPagedTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsGuest(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsGuest($this->browsers->guest, $forum, $topic);
+    }
+
+    #[Attributes\Depends('testTopicEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsAdmin(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsAdmin($this->browsers->admin, $forum, $topic);
+    }
+
+    #[Attributes\Depends('testTopicEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicSubmitEditAsAdmin(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicSubmitEditAsAdmin($this->browsers->admin, $forum, $topic, PostUtilities::copyAndEditTitleAndContent($topic));
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsActive/TopicNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/TopicNumericEditTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractTopicEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class TopicNumericEditTest extends AbstractTopicEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksRequests = true;
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(TopicEditTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsGuest(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsGuest($this->browsers->guest, $forum, $topic);
+    }
+
+    #[Attributes\Depends('testTopicEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsAdmin(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsAdmin($this->browsers->admin, $forum, $topic);
+    }
+
+    #[Attributes\Depends('testTopicEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicSubmitEditAsAdmin(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicSubmitEditAsAdmin($this->browsers->admin, $forum, $topic, PostUtilities::copyAndEditTitleAndContent($topic));
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ActivatePluginTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ActivatePluginTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes;
 #[Attributes\CoversNothing]
 class ActivatePluginTest extends AbstractHttpTestCase
 {
-    #[Attributes\DependsOnClass(TopicPagedTest::class)]
+    #[Attributes\DependsOnClass(TopicEditTest::class)]
     public function testActivatePlugin(): void
     {
         $this->browsers->admin->followRedirects(true);

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/TopicEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/TopicEditTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsNotActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractTopicEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class TopicEditTest extends AbstractTopicEditTest
+{
+    #[Attributes\DependsOnClass(TopicPagedTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsGuest(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsGuest($this->browsers->guest, $forum, $topic);
+    }
+
+    #[Attributes\Depends('testTopicEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getTopics')]
+    public function testTopicEditAsAdmin(Forum $forum, Topic $topic): void
+    {
+        $this->_testTopicEditAsAdmin($this->browsers->admin, $forum, $topic);
+    }
+}

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Type;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
@@ -13,9 +14,15 @@ class FrontendUtilities
 {
     public static function submitEditForm(HttpBrowser $browser, Crawler $crawler, BbPressPostInterface $post): void
     {
+        $form = static::findEditForm($crawler);
         $type = $post->getType()->value;
+
+        if ($type === Type::Topic->value) {
+            $form->remove('bbp_log_topic_edit');
+        }
+
         $browser->submit(
-            static::findEditForm($crawler),
+            $form,
             [
                 'bbp_'.$type.'_title' => $post->getTitle(),
                 'bbp_'.$type.'_content' => $post->getContent(),

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 
 class FrontendUtilities
 {
-    public static function submitEditForm(HttpBrowser $browser, Crawler $crawler, AbstractPost $post): void
+    public static function submitEditForm(HttpBrowser $browser, Crawler $crawler, BbPressPostInterface $post): void
     {
+        $type = $post->getType()->value;
         $browser->submit(
             static::findEditForm($crawler),
             [
-                'bbp_forum_title' => $post->getTitle(),
-                'bbp_forum_content' => $post->getContent(),
+                'bbp_'.$type.'_title' => $post->getTitle(),
+                'bbp_'.$type.'_content' => $post->getContent(),
             ],
         );
     }

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Type;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
@@ -16,10 +15,6 @@ class FrontendUtilities
     {
         $form = static::findEditForm($crawler);
         $type = $post->getType()->value;
-
-        if ($type === Type::Topic->value) {
-            $form->remove('bbp_log_topic_edit');
-        }
 
         $browser->submit(
             $form,

--- a/.github/tests/application/tests/Utilities/PostUtilities.php
+++ b/.github/tests/application/tests/Utilities/PostUtilities.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\PostInterface;
 
 class PostUtilities
 {
@@ -15,7 +16,7 @@ class PostUtilities
      *
      * @return Type
      */
-    public static function copyAndEditTitleAndContent(AbstractPost $post): AbstractPost
+    public static function copyAndEditTitleAndContent(PostInterface $post): AbstractPost
     {
         $editedPost = clone $post;
 

--- a/.github/tests/application/tests/Utilities/PostUtilities.php
+++ b/.github/tests/application/tests/Utilities/PostUtilities.php
@@ -22,7 +22,11 @@ class PostUtilities
         $editTitleString = implode('_', ['EDIT', Random::positiveInteger()]);
         $editContentString = implode('_', ['EDIT', Random::positiveInteger()]);
 
-        $editedPost->setTitle(implode(' ', [$editTitleString, $post->getTitle(), $editTitleString]));
+        /*
+         * Do not make titles too long. bbPress validates length of titles.
+         * @see bbp_is_title_too_long
+         */
+        $editedPost->setTitle(implode(' ', [$post->getTitle(), $editTitleString]));
         $editedPost->setContent(implode(' ', [$editContentString, $post->getContent(), $editContentString]));
 
         return $editedPost;

--- a/.github/tests/application/tests/Utilities/URL.php
+++ b/.github/tests/application/tests/Utilities/URL.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 
 class URL
@@ -18,7 +18,7 @@ class URL
         );
     }
 
-    public static function editPermalink(Forum|Reply|Topic $post, bool $useNumericPermalinks): string
+    public static function editPermalink(BbPressPostInterface $post, bool $useNumericPermalinks): string
     {
         $permalink = $useNumericPermalinks ? $post->getNumericPermalink() : $post->getSamplePermalink();
 


### PR DESCRIPTION
Continue adding tests as started in https://github.com/korobochkin/bbpress-permalinks-with-id/pull/27, but this time for `edit` topic pages. The same as for forums, the tests include 1) requesting the page, 2) checking elements on pages, and 3) submitting a form with an updated title and content.