### PR TITLE
Application Tests. Edit replies

### DIFF
--- a/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
@@ -36,7 +36,7 @@ abstract class AbstractReplyEditTest extends AbstractHttpTestCase
 
         $crawler2 = $this->requestEditPage($browser, $reply);
 
-        $this->testReplyEditPage($browser, $forum, $topic, $newReply, $crawler2);
+        $this->testReplyEditPageAfterEdit($browser, $forum, $topic, $newReply, $crawler2);
 
         // Rollback to the original content
         FrontendUtilities::submitEditForm($browser, $crawler2, $reply);
@@ -51,6 +51,26 @@ abstract class AbstractReplyEditTest extends AbstractHttpTestCase
 
     private function testReplyEditPage(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Crawler $crawler): void
     {
+        $this->assertPageStatusIs200($browser->getResponse());
+        $this->assertPageTitleEquals($reply->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($topic->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($reply->getTitle(), $crawler);
+
+        $this->assertReplyEditFormHasId($reply, $crawler);
+        $this->assertReplyEditFormHasContent($reply, $crawler);
+        $this->assertReplyEditFormHasSubmit($crawler);
+    }
+
+    private function testReplyEditPageAfterEdit(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Crawler $crawler): void
+    {
+        /*
+         * bbPress doesn't have title field in frontend form for replies.
+         * But after submitting a form, it erases the actual title in the DB.
+         * After that bbPress starts using "Reply To: $TOPIC_TITLE" instead.
+         *
+         * @see FrontendUtilities::submitEditForm
+         */
         $this->assertPageStatusIs200($browser->getResponse());
         $this->assertPageTitleEquals($replyToTitle = 'Reply To: '.$topic->getTitle(), $crawler);
         $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);

--- a/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser\FrontendUtilities;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\URL;
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class AbstractReplyEditTest extends AbstractHttpTestCase
+{
+    protected function _testReplyEditAsGuest(HttpBrowser $browser, Topic $topic, Reply $reply): void
+    {
+        $this->requestEditPage($browser, $reply);
+        $this->assertEditPageRedirected($browser, $topic, $reply);
+    }
+
+    protected function _testReplyEditAsAdmin(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $crawler = $this->requestEditPage($browser, $reply);
+        $this->testReplyEditPage($browser, $forum, $topic, $reply, $crawler);
+    }
+
+    protected function _testReplySubmitEditAsAdmin(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Reply $newReply): void
+    {
+        $crawler = $this->requestEditPage($browser, $reply);
+
+        FrontendUtilities::submitEditForm($browser, $crawler, $newReply);
+
+        $this->assertEditPageRedirected($browser, $topic, $reply);
+
+        $crawler2 = $this->requestEditPage($browser, $reply);
+
+        $this->testReplyEditPage($browser, $forum, $topic, $newReply, $crawler2);
+
+        // Rollback to the original content
+        FrontendUtilities::submitEditForm($browser, $crawler2, $reply);
+    }
+
+    private function requestEditPage(HttpBrowser $browser, Reply $reply): Crawler
+    {
+        $browser->followRedirects(false);
+
+        return $browser->request('GET', URL::editPermalink($reply, $this->useNumericPermalinksRequests));
+    }
+
+    private function testReplyEditPage(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Crawler $crawler): void
+    {
+        $this->assertPageStatusIs200($browser->getResponse());
+        $this->assertPageTitleEquals($replyToTitle = 'Reply To: '.$topic->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($topic->getTitle(), $crawler);
+        $this->assertBbPressBreadCrumbsContains($replyToTitle, $crawler);
+
+        $this->assertReplyEditFormHasId($reply, $crawler);
+        $this->assertReplyEditFormHasContent($reply, $crawler);
+        $this->assertReplyEditFormHasSubmit($crawler);
+    }
+
+    private function assertEditPageRedirected(HttpBrowser $browser, Topic $topic, Reply $reply): void
+    {
+        $this->assertIsRedirect($browser->getResponse());
+
+        $this->assertThat(
+            $browser->getResponse()->getHeader('location'),
+            $this->logicalOr(
+                $this->equalTo(URL::replyAnchoredPermalink($topic, $reply, $this->useNumericPermalinksHTML)),
+                $this->logicalAnd(
+                    $this->stringStartsWith($this->useNumericPermalinksHTML ? $topic->getNumericPermalink() : $topic->getSamplePermalink()),
+                    $this->stringEndsWith(URL::replyAnchor($reply)),
+                ),
+            ),
+        );
+    }
+
+    private function assertReplyEditFormHasId(Reply $reply, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//input[@type="hidden" and @name="bbp_reply_id"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($reply->getId(), $input->attr('value'));
+    }
+
+    private function assertReplyEditFormHasContent(Reply $reply, Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//textarea[@name="bbp_reply_content"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals($reply->getContent(), $input->innerText());
+    }
+
+    private function assertReplyEditFormHasSubmit(Crawler $crawler): void
+    {
+        $input = $crawler->filterXPath('//body//div[contains(@class, "entry-content")]//form[@name="new-post"]//button[@name="bbp_reply_submit"]');
+
+        $this->assertCount(1, $input);
+        $this->assertEquals('Submit', $input->text());
+    }
+}

--- a/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
@@ -63,7 +63,7 @@ abstract class AbstractReplyEditTest extends AbstractHttpTestCase
     {
         $expectedReplyTitle = $reply->getTitle();
 
-        if ($expectedReplyTitle) {
+        if ('' === $expectedReplyTitle) {
             $expectedReplyTitle = 'Reply To: '.$topic->getTitle();
         }
 

--- a/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
+++ b/.github/tests/application/tests/Abstracts/AbstractReplyEditTest.php
@@ -32,11 +32,21 @@ abstract class AbstractReplyEditTest extends AbstractHttpTestCase
 
         FrontendUtilities::submitEditForm($browser, $crawler, $newReply);
 
+        /*
+         * bbPress doesn't have title field in frontend form for replies.
+         * But after submitting a form, it erases the actual title in the DB.
+         * After that bbPress starts using "Reply To: $TOPIC_TITLE" instead.
+         *
+         * @see FrontendUtilities::submitEditForm
+         */
+        $reply->setTitle('');
+        $newReply->setTitle('');
+
         $this->assertEditPageRedirected($browser, $topic, $reply);
 
         $crawler2 = $this->requestEditPage($browser, $reply);
 
-        $this->testReplyEditPageAfterEdit($browser, $forum, $topic, $newReply, $crawler2);
+        $this->testReplyEditPage($browser, $forum, $topic, $newReply, $crawler2);
 
         // Rollback to the original content
         FrontendUtilities::submitEditForm($browser, $crawler2, $reply);
@@ -51,31 +61,17 @@ abstract class AbstractReplyEditTest extends AbstractHttpTestCase
 
     private function testReplyEditPage(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Crawler $crawler): void
     {
+        $expectedReplyTitle = $reply->getTitle();
+
+        if ($expectedReplyTitle) {
+            $expectedReplyTitle = 'Reply To: '.$topic->getTitle();
+        }
+
         $this->assertPageStatusIs200($browser->getResponse());
-        $this->assertPageTitleEquals($reply->getTitle(), $crawler);
+        $this->assertPageTitleEquals($expectedReplyTitle, $crawler);
         $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
         $this->assertBbPressBreadCrumbsContains($topic->getTitle(), $crawler);
-        $this->assertBbPressBreadCrumbsContains($reply->getTitle(), $crawler);
-
-        $this->assertReplyEditFormHasId($reply, $crawler);
-        $this->assertReplyEditFormHasContent($reply, $crawler);
-        $this->assertReplyEditFormHasSubmit($crawler);
-    }
-
-    private function testReplyEditPageAfterEdit(HttpBrowser $browser, Forum $forum, Topic $topic, Reply $reply, Crawler $crawler): void
-    {
-        /*
-         * bbPress doesn't have title field in frontend form for replies.
-         * But after submitting a form, it erases the actual title in the DB.
-         * After that bbPress starts using "Reply To: $TOPIC_TITLE" instead.
-         *
-         * @see FrontendUtilities::submitEditForm
-         */
-        $this->assertPageStatusIs200($browser->getResponse());
-        $this->assertPageTitleEquals($replyToTitle = 'Reply To: '.$topic->getTitle(), $crawler);
-        $this->assertBbPressBreadCrumbsContains($forum->getTitle(), $crawler);
-        $this->assertBbPressBreadCrumbsContains($topic->getTitle(), $crawler);
-        $this->assertBbPressBreadCrumbsContains($replyToTitle, $crawler);
+        $this->assertBbPressBreadCrumbsContains($expectedReplyTitle, $crawler);
 
         $this->assertReplyEditFormHasId($reply, $crawler);
         $this->assertReplyEditFormHasContent($reply, $crawler);

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -145,7 +145,7 @@ class ForumDataProvider
         $reply
             ->setTitle(implode(' ', ['Reply #', $number, $random]))
             ->setContent($number.' '.Random::sentence())
-            ->setName(implode('-', ['topic-slug', $forumIteration, $topicIteration, $replyIteration, $random, 'end']))
+            ->setName(implode('-', ['reply-slug', $forumIteration, $topicIteration, $replyIteration, $random, 'end']))
         ;
 
         return $reply;

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -69,6 +69,13 @@ class ForumDataProvider
         return self::$instance->repliesGenerator();
     }
 
+    public static function getRepliesEdit(): \Generator
+    {
+        self::prepareInstance();
+
+        return self::$instance->repliesEditGenerator();
+    }
+
     private static function prepareInstance(): void
     {
         if (!isset(self::$instance)) {
@@ -246,6 +253,34 @@ class ForumDataProvider
 
                         yield $i++ => [$forum, $topic, $page, $slice];
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{Forum, Topic, Reply}, mixed, void>
+     */
+    private function repliesEditGenerator(): \Generator
+    {
+        $i = 0;
+        foreach ($this->data as [$forum, $topicsAndReplies]) {
+            if (empty($topicsAndReplies)) {
+                continue;
+            }
+
+            $topicIndices = array_unique([array_key_first($topicsAndReplies), array_key_last($topicsAndReplies)]);
+
+            foreach ($topicIndices as $topicIndex) {
+                [$topic, $replies] = $topicsAndReplies[$topicIndex];
+                if (empty($replies)) {
+                    continue;
+                }
+
+                $replyIndices = array_unique([array_key_first($replies), array_key_last($replies)]);
+
+                foreach ($replyIndices as $replyIndex) {
+                    yield $i++ => [$forum, $topic, $replies[$replyIndex]];
                 }
             }
         }

--- a/.github/tests/application/tests/Entities/Posts/Type.php
+++ b/.github/tests/application/tests/Entities/Posts/Type.php
@@ -15,4 +15,12 @@ enum Type: string
     case Topic = 'topic';
 
     case Reply = 'reply';
+
+    public function hasTitle(): bool
+    {
+        return match ($this) {
+            self::Forum, self::Topic => true,
+            default => false,
+        };
+    }
 }

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyEditTest.php
@@ -25,21 +25,21 @@ class ReplyEditTest extends AbstractReplyEditTest
     }
 
     #[Attributes\DependsOnClass(ReplyNumericTest::class)]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);
     }
 
     #[Attributes\Depends('testReplyEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplyEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplyEditAsAdmin($this->browsers->admin, $forum, $topic, $reply);
     }
 
     #[Attributes\Depends('testReplyEditAsAdmin')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplySubmitEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplySubmitEditAsAdmin($this->browsers->admin, $forum, $topic, $reply, PostUtilities::copyAndEditTitleAndContent($reply));

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyEditTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractReplyEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ReplyEditTest extends AbstractReplyEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(ReplyNumericTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);
+    }
+
+    #[Attributes\Depends('testReplyEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplyEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsAdmin($this->browsers->admin, $forum, $topic, $reply);
+    }
+
+    #[Attributes\Depends('testReplyEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplySubmitEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplySubmitEditAsAdmin($this->browsers->admin, $forum, $topic, $reply, PostUtilities::copyAndEditTitleAndContent($reply));
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyNumericEditTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractReplyEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\PostUtilities;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ReplyNumericEditTest extends AbstractReplyEditTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useNumericPermalinksRequests = true;
+        $this->useNumericPermalinksHTML = true;
+    }
+
+    #[Attributes\DependsOnClass(ReplyEditTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);
+    }
+
+    #[Attributes\Depends('testReplyEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplyEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsAdmin($this->browsers->admin, $forum, $topic, $reply);
+    }
+
+    #[Attributes\Depends('testReplyEditAsAdmin')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    public function testReplySubmitEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplySubmitEditAsAdmin($this->browsers->admin, $forum, $topic, $reply, PostUtilities::copyAndEditTitleAndContent($reply));
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsActive/ReplyNumericEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsActive/ReplyNumericEditTest.php
@@ -26,21 +26,21 @@ class ReplyNumericEditTest extends AbstractReplyEditTest
     }
 
     #[Attributes\DependsOnClass(ReplyEditTest::class)]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);
     }
 
     #[Attributes\Depends('testReplyEditAsGuest')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplyEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplyEditAsAdmin($this->browsers->admin, $forum, $topic, $reply);
     }
 
     #[Attributes\Depends('testReplyEditAsAdmin')]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
     public function testReplySubmitEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplySubmitEditAsAdmin($this->browsers->admin, $forum, $topic, $reply, PostUtilities::copyAndEditTitleAndContent($reply));

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyEditTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\TestCases\PluginIsNotActive;
+
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts\AbstractReplyEditTest;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use PHPUnit\Framework\Attributes;
+
+/**
+ * @internal
+ */
+#[Attributes\CoversNothing]
+class ReplyEditTest extends AbstractReplyEditTest
+{
+    #[Attributes\DependsOnClass(ReplyTest::class)]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
+    public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);
+    }
+
+    #[Attributes\Depends('testReplyEditAsGuest')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
+    public function testReplyEditAsAdmin(Forum $forum, Topic $topic, Reply $reply): void
+    {
+        $this->_testReplyEditAsAdmin($this->browsers->admin, $forum, $topic, $reply);
+    }
+}

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyEditTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/ReplyEditTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Attributes;
 class ReplyEditTest extends AbstractReplyEditTest
 {
     #[Attributes\DependsOnClass(ReplyTest::class)]
-    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesEdit')]
+    #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getReplies')]
     public function testReplyEditAsGuest(Forum $forum, Topic $topic, Reply $reply): void
     {
         $this->_testReplyEditAsGuest($this->browsers->guest, $topic, $reply);

--- a/.github/tests/application/tests/TestCases/PluginIsNotActive/TopicPagedTest.php
+++ b/.github/tests/application/tests/TestCases/PluginIsNotActive/TopicPagedTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes;
 #[Attributes\CoversNothing]
 class TopicPagedTest extends AbstractTopicPagedTest
 {
-    #[Attributes\DependsOnClass(ReplyTest::class)]
+    #[Attributes\DependsOnClass(ReplyEditTest::class)]
     #[Attributes\DataProviderExternal(ForumDataProvider::class, 'getRepliesPaged')]
     public function testTopicPagedAsGuest(Forum $forum, Topic $topic, int $page, array $replies): void
     {

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Type;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
@@ -19,7 +20,12 @@ class FrontendUtilities
         $browser->submit(
             $form,
             [
-                'bbp_'.$type.'_title' => $post->getTitle(),
+                ...(
+                    Type::Forum === $post->getType()
+                    || Type::Topic === $post->getType()
+                        ? ['bbp_'.$type.'_title' => $post->getTitle()]
+                        : []
+                ),
                 'bbp_'.$type.'_content' => $post->getContent(),
             ],
         );

--- a/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
+++ b/.github/tests/application/tests/Utilities/Browser/FrontendUtilities.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\Browser;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
-use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Type;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\HttpBrowser;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
@@ -21,10 +20,9 @@ class FrontendUtilities
             $form,
             [
                 ...(
-                    Type::Forum === $post->getType()
-                    || Type::Topic === $post->getType()
-                        ? ['bbp_'.$type.'_title' => $post->getTitle()]
-                        : []
+                    $post->getType()->hasTitle()
+                    ? ['bbp_'.$type.'_title' => $post->getTitle()]
+                    : []
                 ),
                 'bbp_'.$type.'_content' => $post->getContent(),
             ],

--- a/.github/tests/application/tests/Utilities/URL.php
+++ b/.github/tests/application/tests/Utilities/URL.php
@@ -6,6 +6,7 @@ namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
 
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Forum;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\BbPressPostInterface;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 
 class URL
@@ -27,6 +28,22 @@ class URL
         }
 
         return $permalink.'edit/';
+    }
+
+    public static function replyAnchoredPermalink(Topic $topic, Reply $reply, bool $useNumericPermalinks): string
+    {
+        $permalink = $useNumericPermalinks ? $topic->getNumericPermalink() : $topic->getSamplePermalink();
+
+        if (!str_ends_with($permalink, '/')) {
+            throw new \LogicException('Invalid permalink format');
+        }
+
+        return $permalink.self::replyAnchor($reply);
+    }
+
+    public static function replyAnchor(Reply $reply): string
+    {
+        return '#post-'.$reply->getId();
     }
 
     private static function paged(string $permalink, int $page): string


### PR DESCRIPTION
Tests for reply `edit` pages. Those tests are slightly different from Forums and Topics because Replies do not have title field in the edit form. Also I fixed slugs for all Replies in the `ForumDataProvider` class. The amount of Replies to test in edit tests was reduced to 2 reply per each topic - the first one and the last one in each Topic (see `ForumDataProvider::getRepliesEdit`).

Related PRs:
- https://github.com/korobochkin/bbpress-permalinks-with-id/pull/27
- https://github.com/korobochkin/bbpress-permalinks-with-id/pull/32