### PR TITLE
Dependabot config updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,11 @@ updates:
       - .github/phpcs
       - .github/phpmd
       - .github/psalm
+      - .github/tests/application
     versioning-strategy: increase
     cooldown:
       default-days: 10
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     schedule:
       interval: weekly
 
@@ -18,4 +19,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,9 @@ updates:
       interval: weekly
 
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - .github/actions/hooks-generator
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
- Added sub projects for scanning:
  - `.github/tests/application` 
  - `.github/tests/application`
- Increased `open-pull-requests-limit`.