### PR TITLE
Fix inccorect order of entities in application tests

### DIFF
--- a/.github/tests/application/containers/wordpress/mu-plugins/configurator.php
+++ b/.github/tests/application/containers/wordpress/mu-plugins/configurator.php
@@ -60,9 +60,7 @@ add_action('admin_init', 'configurator_disable_auto_updates');
 
 function configurator_bbp_after_has_topics_parse_args(array $params): array
 {
-    if (isset($params['orderby'])) {
-        $params['orderby'] = 'date';
-    }
+    $params['orderby'] = 'date';
 
     return $params;
 }

--- a/.github/tests/application/containers/wordpress/mu-plugins/configurator.php
+++ b/.github/tests/application/containers/wordpress/mu-plugins/configurator.php
@@ -57,3 +57,13 @@ function configurator_disable_auto_updates()
     remove_all_filters('plugins_api');
 }
 add_action('admin_init', 'configurator_disable_auto_updates');
+
+function configurator_bbp_after_has_topics_parse_args(array $params): array
+{
+    if (isset($params['orderby'])) {
+        $params['orderby'] = 'date';
+    }
+
+    return $params;
+}
+add_filter('bbp_after_has_topics_parse_args', 'configurator_bbp_after_has_topics_parse_args');

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -25,6 +25,8 @@ final class ForumDataProvider
 
     private \DateTime $postDateTimeCounter;
 
+    private \DateInterval $postDateInterval;
+
     /**
      * @var non-empty-array<int<0, max>, array{0: Forum, 1: list<array{0: Topic, 1: list<Reply>}>}>
      */
@@ -34,9 +36,10 @@ final class ForumDataProvider
      * @throws \Random\RandomException
      * @throws \RuntimeException
      */
-    public function __construct(\DateTime $initialDateTime)
+    public function __construct(\DateTime $initialDateTime, \DateInterval $interval)
     {
         $this->postDateTimeCounter = $initialDateTime;
+        $this->postDateInterval = $interval;
         $this->prepare();
     }
 
@@ -103,11 +106,13 @@ final class ForumDataProvider
     /**
      * @throws \Random\RandomException
      * @throws \RuntimeException
+     * @throws \Exception
      */
     public static function prepareInstance(): void
     {
         self::$instance = new self(
             new \DateTime('-3 months', new \DateTimeZone('UTC'))->setTime(0, 0, 0, 0),
+            new \DateInterval('PT3H'),
         );
     }
 
@@ -351,7 +356,7 @@ final class ForumDataProvider
     private function buildPostDate(): \DateTime
     {
         $date = clone $this->postDateTimeCounter;
-        $this->postDateTimeCounter->modify('+3 hours');
+        $this->postDateTimeCounter->add($this->postDateInterval);
 
         return $date;
     }

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -23,6 +23,8 @@ final class ForumDataProvider
 
     private int $repliesPerPage = 15;
 
+    private \DateTime $postDateTimeCounter;
+
     /**
      * @var non-empty-array<int<0, max>, array{0: Forum, 1: list<array{0: Topic, 1: list<Reply>}>}>
      */
@@ -32,8 +34,9 @@ final class ForumDataProvider
      * @throws \Random\RandomException
      * @throws \RuntimeException
      */
-    public function __construct()
+    public function __construct(\DateTime $initialDateTime)
     {
+        $this->postDateTimeCounter = $initialDateTime;
         $this->prepare();
     }
 
@@ -103,7 +106,9 @@ final class ForumDataProvider
      */
     public static function prepareInstance(): void
     {
-        self::$instance = new self();
+        self::$instance = new self(
+            new \DateTime('-3 months', new \DateTimeZone('UTC'))->setTime(0, 0, 0, 0),
+        );
     }
 
     /**
@@ -115,9 +120,11 @@ final class ForumDataProvider
         $data = [];
 
         for ($i = 0; $i < $this->numberOfForums; ++$i) {
+            $forum = $this->buildForum($i);
             $topicsAndReplies = [];
 
             for ($j = 0; $j < $this->numberOfTopics; ++$j) {
+                $topic = $this->buildTopic($i, $j);
                 $replies = [];
 
                 if ($j < 2) {
@@ -131,13 +138,13 @@ final class ForumDataProvider
                 }
 
                 $topicsAndReplies[] = [
-                    0 => $this->buildTopic($i, $j),
+                    0 => $topic,
                     1 => $replies,
                 ];
             }
 
             $data[$i] = [
-                0 => $this->buildForum($i),
+                0 => $forum,
                 1 => $topicsAndReplies,
             ];
         }
@@ -162,6 +169,7 @@ final class ForumDataProvider
             ->setTitle(implode(' ', ['Forum #', $forumIteration, $random]))
             ->setContent(Random::sentence())
             ->setName(implode('-', ['forum-slug', $forumIteration, $random, 'end']))
+            ->setPostDate($this->buildPostDate())
         ;
 
         return $post;
@@ -183,6 +191,7 @@ final class ForumDataProvider
             ->setTitle(implode(' ', ['Topic #', $number, $random]))
             ->setContent($number.' '.Random::sentence())
             ->setName(implode('-', ['topic-slug', $forumIteration, $topicIteration, $random, 'end']))
+            ->setPostDate($this->buildPostDate())
         ;
 
         return $topic;
@@ -205,6 +214,7 @@ final class ForumDataProvider
             ->setTitle(implode(' ', ['Reply #', $number, $random]))
             ->setContent($number.' '.Random::sentence())
             ->setName(implode('-', ['reply-slug', $forumIteration, $topicIteration, $replyIteration, $random, 'end']))
+            ->setPostDate($this->buildPostDate())
         ;
 
         return $reply;
@@ -336,5 +346,13 @@ final class ForumDataProvider
                 }
             }
         }
+    }
+
+    private function buildPostDate(): \DateTime
+    {
+        $date = clone $this->postDateTimeCounter;
+        $this->postDateTimeCounter->modify('+3 hours');
+
+        return $date;
     }
 }

--- a/.github/tests/application/tests/Entities/Posts/AbstractPost.php
+++ b/.github/tests/application/tests/Entities/Posts/AbstractPost.php
@@ -25,6 +25,8 @@ abstract class AbstractPost implements PostInterface
      */
     private string $samplePermalink;
 
+    private \DateTime $postDate;
+
     #[\Override]
     public function getId(): int
     {
@@ -140,5 +142,19 @@ abstract class AbstractPost implements PostInterface
         }
 
         return $result;
+    }
+
+    #[\Override]
+    public function getPostDate(): \DateTime
+    {
+        return $this->postDate;
+    }
+
+    #[\Override]
+    public function setPostDate(\DateTime $postDate): self
+    {
+        $this->postDate = $postDate;
+
+        return $this;
     }
 }

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
@@ -62,4 +62,11 @@ interface PostInterface
      * @throws \RuntimeException
      */
     public function getNumericPermalink(): string;
+
+    public function getPostDate(): \DateTime;
+
+    /**
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
+    public function setPostDate(\DateTime $postDate): self;
 }

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -90,6 +90,15 @@ final class BrowserActions
             'post_title' => $post->getTitle(),
             'content' => $post->getContent(),
             'post_name' => $post->getName(),
+
+            // Publish date
+            'aa' => $post->getPostDate()->format('Y'), // year
+            'mm' => $post->getPostDate()->format('m'), // month
+            'jj' => $post->getPostDate()->format('d'), // date
+            // Publish time
+            'hh' => $post->getPostDate()->format('H'), // hour
+            'mn' => $post->getPostDate()->format('i'), // minute
+            'ss' => $post->getPostDate()->format('s'), // second
         ];
 
         if ($post instanceof Topic) {


### PR DESCRIPTION
Because bbPress entities (`Forum`, `Topic`, `Reply`) are created in a loop and almost simultaneously during application test execution, this results in an incorrect order on pages. As a consequence, multiple tests were failing due to this unpredictable ordering.

The solution is to use predefined `\Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\AbstractPost::$postDate` values that are built inside `\Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider`. The system assigns a simple sequential order to all created entities with a 3-hour interval between each. See `\Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider::prepare`.

Additionally, I added the `configurator_bbp_after_has_topics_parse_args` function to fix the `orderby` behavior inside bbPress for the Forums page (the page that displays topics). By default, bbPress orders topics by `wp_postmeta.meta_value` from `wp_postmeta.meta_key = '_bbp_last_active_time'`.