### PR TITLE
Track PHP logs (errors, warnings) in Applicaiton Tests

### DIFF
--- a/.github/tests/application/Makefile
+++ b/.github/tests/application/Makefile
@@ -11,7 +11,7 @@ config:
 	@docker compose config --quiet
 
 reset_logs:
-	docker exec syslog sh -c "truncate -s 0 /var/log/remote/*.log"
+	docker exec syslog sh -c "find /var/log/remote -maxdepth 1 -type f -name '*.log' -exec truncate -s 0 {} \;"
 
 vendor: composer.json composer.lock
 	composer install --no-interaction --no-progress --classmap-authoritative

--- a/.github/tests/application/Makefile
+++ b/.github/tests/application/Makefile
@@ -10,6 +10,9 @@ down:
 config:
 	@docker compose config --quiet
 
+reset_logs:
+	docker exec syslog sh -c "truncate -s 0 /var/log/remote/*.log"
+
 vendor: composer.json composer.lock
 	composer install --no-interaction --no-progress --classmap-authoritative
 
@@ -30,6 +33,7 @@ php_cs_fixer:
 	up \
 	down \
 	config \
+	reset_logs \
 	composer_install_from_host \
 	run_tests \
 	run_tests_from_host \

--- a/.github/tests/application/containers/syslog/rsyslog.conf
+++ b/.github/tests/application/containers/syslog/rsyslog.conf
@@ -1,14 +1,12 @@
 module(load="imudp")
 input(type="imudp" port="1514")
 
-template(name="JsonLog" type="list") {
-    constant(value="{")
-    constant(value="\"timestamp\":\"")      property(name="timegenerated" dateFormat="rfc3339")
-    constant(value="\",\"severity\":\"")    property(name="syslogseverity-text")
-    constant(value="\",\"severity_code\":") property(name="syslogseverity")
-    constant(value=",\"tag\":\"")           property(name="syslogtag")
-    constant(value="\",\"message\":\"")     property(name="msg" format="jsonf")
-    constant(value="\"}\n")
+template(name="JsonLog" type="list" option.jsonf="on") {
+    property(name="timegenerated" dateFormat="rfc3339" format="jsonf" outname="timestamp")
+    property(name="syslogseverity-text" format="jsonf" outname="severity")
+    property(name="syslogseverity" format="jsonf" outname="severity_code")
+    property(name="syslogtag" format="jsonf" outname="tag")
+    property(name="msg" format="jsonf" outname="message")
 }
 
 *.* /var/log/remote/wordpress-all.log;JsonLog

--- a/.github/tests/application/containers/syslog/rsyslog.conf
+++ b/.github/tests/application/containers/syslog/rsyslog.conf
@@ -1,0 +1,15 @@
+module(load="imudp")
+input(type="imudp" port="1514")
+
+template(name="JsonLog" type="list") {
+    constant(value="{")
+    constant(value="\"timestamp\":\"")      property(name="timegenerated" dateFormat="rfc3339")
+    constant(value="\",\"severity\":\"")    property(name="syslogseverity-text")
+    constant(value="\",\"severity_code\":") property(name="syslogseverity")
+    constant(value=",\"tag\":\"")           property(name="syslogtag")
+    constant(value="\",\"message\":\"")     property(name="msg" format="jsonf")
+    constant(value="\"}\n")
+}
+
+*.* /var/log/remote/wordpress-all.log;JsonLog
+*.err /var/log/remote/wordpress-errors.log;JsonLog

--- a/.github/tests/application/containers/syslog/syslog.Dockerfile
+++ b/.github/tests/application/containers/syslog/syslog.Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3
+
+RUN mkdir -p /var/log/remote && \
+    apk --no-cache add rsyslog net-tools
+
+COPY rsyslog.conf /etc/rsyslog.conf
+
+EXPOSE 1514/udp
+
+CMD ["rsyslogd", "-n", "-f", "/etc/rsyslog.conf"]

--- a/.github/tests/application/docker-compose.yml
+++ b/.github/tests/application/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - '127.0.0.1:1514:1514/udp'
     healthcheck:
-      test: ["CMD", "sh", "-c", "netstat -uln | grep -q 1514"]
+      test: ["CMD-SHELL", "netstat -uln | grep -q 1514"]
       start_period: 3s
       start_interval: 1s
       timeout: 2s

--- a/.github/tests/application/docker-compose.yml
+++ b/.github/tests/application/docker-compose.yml
@@ -1,5 +1,21 @@
 ---
 services:
+  syslog:
+    container_name: syslog
+    build:
+      context: ./containers/syslog
+      dockerfile: ./syslog.Dockerfile
+    volumes:
+      - syslog_data:/var/log/remote
+    ports:
+      - '127.0.0.1:1514:1514/udp'
+    healthcheck:
+      test: ["CMD", "sh", "-c", "netstat -uln | grep -q 1514"]
+      start_period: 3s
+      start_interval: 1s
+      timeout: 2s
+      retries: 3
+
   wordpress:
     container_name: wordpress
     build:
@@ -31,8 +47,15 @@ services:
     volumes:
       - wordpress_data:/var/www/html
       - ../../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "udp://127.0.0.1:1514"
+        tag: "wordpress"
     depends_on:
       db:
+        condition: service_healthy
+      syslog:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "test", "-f", "/var/www/html/wp-config.php"]
@@ -94,6 +117,7 @@ services:
     volumes:
       - ./:/root/tests-application
       - ./php-configs/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+      - syslog_data:/var/log/remote:ro
     ports:
       - '127.0.0.1:9009:9009'
     environment:
@@ -105,5 +129,6 @@ services:
         condition: service_healthy
 
 volumes:
+  syslog_data:
   wordpress_data:
   db_data:

--- a/.github/tests/application/docker-compose.yml
+++ b/.github/tests/application/docker-compose.yml
@@ -130,5 +130,10 @@ services:
 
 volumes:
   syslog_data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=10m
   wordpress_data:
   db_data:

--- a/.github/tests/application/phpunit-bootstrap.php
+++ b/.github/tests/application/phpunit-bootstrap.php
@@ -7,7 +7,9 @@ require __DIR__.'/vendor/autoload.php';
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumDataProvider;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\DataProviders\ForumsPageDataProvider;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\BrowsersService;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\WordPressServerLogs;
 
 $GLOBALS['BROWSERS_SERVICE'] = new BrowsersService();
+$GLOBALS['WORDPRESS_LOGS_SERVICE'] = new WordPressServerLogs();
 ForumDataProvider::prepareInstance();
 ForumsPageDataProvider::prepareInstance();

--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Abstracts;
 
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Logs\LogEntry;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Interfaces\PostInterface;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
@@ -42,6 +43,9 @@ abstract class AbstractHttpTestCase extends TestCase
 
     protected bool $useNumericPermalinksHTML = false;
 
+    /**
+     * @throws \UnexpectedValueException
+     */
     #[\Override]
     protected function setUp(): void
     {
@@ -49,6 +53,9 @@ abstract class AbstractHttpTestCase extends TestCase
         $this->logs->checkpoint();
     }
 
+    /**
+     * @throws \UnexpectedValueException
+     */
     #[\Override]
     protected function assertPostConditions(): void
     {
@@ -58,7 +65,7 @@ abstract class AbstractHttpTestCase extends TestCase
 
         if ([] !== $newErrors) {
             $messages = array_map(
-                static fn (\stdClass $entry): string => $entry->message ?? '(empty message)',
+                static fn (LogEntry $entry): string => $entry->message,
                 $newErrors,
             );
 

--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -42,6 +42,33 @@ abstract class AbstractHttpTestCase extends TestCase
 
     protected bool $useNumericPermalinksHTML = false;
 
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->logs->checkpoint();
+    }
+
+    #[\Override]
+    protected function assertPostConditions(): void
+    {
+        parent::assertPostConditions();
+
+        $newErrors = $this->logs->getErrorsSinceCheckpoint();
+
+        if ([] !== $newErrors) {
+            $messages = array_map(
+                static fn (\stdClass $entry): string => $entry->message ?? '(empty message)',
+                $newErrors,
+            );
+
+            $this->fail(
+                'WordPress server produced '.count($newErrors)." error(s) during this test:\n"
+                .implode("\n", $messages),
+            );
+        }
+    }
+
     protected function assertPageStatusIs200(Response $response): void
     {
         $this->assertSame(200, $response->getStatusCode());

--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -8,6 +8,7 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Int
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\BrowsersService;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services\WordPressServerLogs;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Crawler;
@@ -23,6 +24,17 @@ abstract class AbstractHttpTestCase extends TestCase
             }
 
             throw new \RuntimeException('BROWSERS_SERVICE not found in $GLOBALS. Ensure phpunit-bootstrap.php is loaded.');
+        }
+    }
+
+    protected WordPressServerLogs $logs {
+        get {
+            if (isset($GLOBALS['WORDPRESS_LOGS_SERVICE'])
+                && is_a($GLOBALS['WORDPRESS_LOGS_SERVICE'], WordPressServerLogs::class)) {
+                return $GLOBALS['WORDPRESS_LOGS_SERVICE'];
+            }
+
+            throw new \RuntimeException('WORDPRESS_LOGS_SERVICE not found in $GLOBALS. Ensure phpunit-bootstrap.php is loaded.');
         }
     }
 

--- a/.github/tests/application/tests/Entities/Logs/LogEntry.php
+++ b/.github/tests/application/tests/Entities/Logs/LogEntry.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Logs;
+
+final readonly class LogEntry
+{
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     *
+     * @var string timestamp in RFC 3339 format
+     */
+    public string $timestamp;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     *
+     * @var string Syslog severity name (e.g. "err", "info", "notice").
+     */
+    public string $severity;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     *
+     * @var int<0, 7> Syslog severity code (e.g. 3 for error, 6 for info).
+     */
+    public int $severityCode;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     *
+     * @var string syslog tag identifying the source container
+     */
+    public string $tag;
+
+    /**
+     * @var string the log message content
+     */
+    public string $message;
+
+    /**
+     * @param int<0, 7> $severityCode
+     */
+    public function __construct(
+        string $timestamp,
+        string $severity,
+        int $severityCode,
+        string $tag,
+        string $message,
+    ) {
+        $this->timestamp = $timestamp;
+        $this->severity = $severity;
+        $this->severityCode = $severityCode;
+        $this->tag = $tag;
+        $this->message = $message;
+    }
+}

--- a/.github/tests/application/tests/Services/WordPressServerLogs.php
+++ b/.github/tests/application/tests/Services/WordPressServerLogs.php
@@ -70,7 +70,7 @@ final class WordPressServerLogs
         $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         if (false === $lines) {
-            return [];
+            throw new \UnexpectedValueException(sprintf('Failed to read log file "%s".', $path));
         }
 
         $entries = [];

--- a/.github/tests/application/tests/Services/WordPressServerLogs.php
+++ b/.github/tests/application/tests/Services/WordPressServerLogs.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services;
+
+final class WordPressServerLogs
+{
+    private const string LOG_DIR = '/var/log/remote';
+
+    private const string ALL_LOG = self::LOG_DIR.'/wordpress-all.log';
+
+    private const string ERRORS_LOG = self::LOG_DIR.'/wordpress-errors.log';
+
+    /**
+     * @return list<\stdClass>
+     */
+    public function getAll(): array
+    {
+        return $this->readLog(self::ALL_LOG);
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    public function getErrors(): array
+    {
+        return $this->readLog(self::ERRORS_LOG);
+    }
+
+    public function hasErrors(): bool
+    {
+        return [] !== $this->getErrors();
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private function readLog(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if (false === $lines) {
+            return [];
+        }
+
+        $entries = [];
+
+        foreach ($lines as $line) {
+            $decoded = json_decode($line);
+
+            if ($decoded instanceof \stdClass) {
+                $entries[] = $decoded;
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/.github/tests/application/tests/Services/WordPressServerLogs.php
+++ b/.github/tests/application/tests/Services/WordPressServerLogs.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Services;
 
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Logs\LogEntry;
+
 final class WordPressServerLogs
 {
     private const string LOG_DIR = '/var/log/remote';
@@ -15,7 +17,11 @@ final class WordPressServerLogs
     private int $errorCheckpoint = 0;
 
     /**
-     * @return list<\stdClass>
+     * @psalm-suppress PossiblyUnusedMethod
+     *
+     * @return list<LogEntry>
+     *
+     * @throws \UnexpectedValueException
      */
     public function getAll(): array
     {
@@ -23,20 +29,27 @@ final class WordPressServerLogs
     }
 
     /**
-     * @return list<\stdClass>
+     * @return list<LogEntry>
+     *
+     * @throws \UnexpectedValueException
      */
     public function getErrors(): array
     {
         return $this->readLog(self::ERRORS_LOG);
     }
 
+    /**
+     * @throws \UnexpectedValueException
+     */
     public function checkpoint(): void
     {
         $this->errorCheckpoint = count($this->getErrors());
     }
 
     /**
-     * @return list<\stdClass>
+     * @return list<LogEntry>
+     *
+     * @throws \UnexpectedValueException
      */
     public function getErrorsSinceCheckpoint(): array
     {
@@ -44,7 +57,9 @@ final class WordPressServerLogs
     }
 
     /**
-     * @return list<\stdClass>
+     * @return list<LogEntry>
+     *
+     * @throws \UnexpectedValueException
      */
     private function readLog(string $path): array
     {
@@ -61,13 +76,35 @@ final class WordPressServerLogs
         $entries = [];
 
         foreach ($lines as $line) {
-            $decoded = json_decode($line);
-
-            if ($decoded instanceof \stdClass) {
-                $entries[] = $decoded;
-            }
+            $entries[] = $this->parseLine($line);
         }
 
         return $entries;
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     */
+    private function parseLine(string $line): LogEntry
+    {
+        $data = json_decode($line, true);
+
+        if (!is_array($data)) {
+            throw new \UnexpectedValueException('Invalid $data object');
+        }
+
+        $severityCode = (int) ($data['severity_code'] ?? 0);
+
+        if ($severityCode < 0 || $severityCode > 7) {
+            throw new \UnexpectedValueException('Bad "severity_code" in log record');
+        }
+
+        return new LogEntry(
+            timestamp: (string) ($data['timestamp'] ?? throw new \UnexpectedValueException('Empty "timestamp" in log record')),
+            severity: (string) ($data['severity'] ?? throw new \UnexpectedValueException('Empty "severity" in log record')),
+            severityCode: $severityCode,
+            tag: (string) ($data['tag'] ?? throw new \UnexpectedValueException('Empty "tag" in log record')),
+            message: (string) ($data['message'] ?? ''),
+        );
     }
 }

--- a/.github/tests/application/tests/Services/WordPressServerLogs.php
+++ b/.github/tests/application/tests/Services/WordPressServerLogs.php
@@ -12,6 +12,8 @@ final class WordPressServerLogs
 
     private const string ERRORS_LOG = self::LOG_DIR.'/wordpress-errors.log';
 
+    private int $errorCheckpoint = 0;
+
     /**
      * @return list<\stdClass>
      */
@@ -28,9 +30,17 @@ final class WordPressServerLogs
         return $this->readLog(self::ERRORS_LOG);
     }
 
-    public function hasErrors(): bool
+    public function checkpoint(): void
     {
-        return [] !== $this->getErrors();
+        $this->errorCheckpoint = count($this->getErrors());
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    public function getErrorsSinceCheckpoint(): array
+    {
+        return array_slice($this->getErrors(), $this->errorCheckpoint);
     }
 
     /**


### PR DESCRIPTION
When CI runs the Application Tests, the test suite in the `php` container checks and validates status codes and HTML content in HTTP responses. During the execution and rendering of HTML pages, the `wordpress` container and its own PHP workers might produce warnings and errors. Before this PR, there was no tracking mechanism for those warnings and errors in tests.

This PR adds an extra container `syslog` that acts as a log server for the `wordpress` container instead of its default `stderr` stream. Then the container that runs the tests (`php`) checks if there are any errors after each test with `AbstractHttpTestCase.assertPostConditions`.