### PR TITLE
Application Tests. Type safety when fetching values from HTML attributes

### DIFF
--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -156,6 +156,7 @@ abstract class AbstractHttpTestCase extends TestCase
      */
     protected function assertBbPressReplyContentContains(Reply|Topic $post, Crawler $crawler): void
     {
+        $this->assertNotEmpty($post->getContent());
         $this->assertStringContainsString(
             $post->getContent(),
             $crawler->filterXPath('//html/body/div[@id="page"]//article//div[contains(@class, "entry-content")]//div[contains(@class, "bbp-reply-content")]/p')->text(),

--- a/.github/tests/application/tests/Entities/Posts/AbstractPost.php
+++ b/.github/tests/application/tests/Entities/Posts/AbstractPost.php
@@ -8,6 +8,9 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Int
 
 abstract class AbstractPost implements PostInterface
 {
+    /**
+     * @var positive-int
+     */
     private int $id;
 
     private Status $status;

--- a/.github/tests/application/tests/Entities/Posts/AbstractPost.php
+++ b/.github/tests/application/tests/Entities/Posts/AbstractPost.php
@@ -18,6 +18,9 @@ abstract class AbstractPost implements PostInterface
 
     private string $name;
 
+    /**
+     * @var positive-int
+     */
     private int $authorId;
 
     /**

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
@@ -36,11 +36,15 @@ interface PostInterface
 
     /**
      * @psalm-suppress PossiblyUnusedMethod
+     *
+     * @return positive-int
      */
     public function getAuthorId(): int;
 
     /**
      * @psalm-suppress PossiblyUnusedReturnValue
+     *
+     * @param positive-int $authorId
      */
     public function setAuthorId(int $authorId): self;
 

--- a/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
+++ b/.github/tests/application/tests/Entities/Posts/Interfaces/PostInterface.php
@@ -9,10 +9,15 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Typ
 
 interface PostInterface
 {
+    /**
+     * @return positive-int
+     */
     public function getId(): int;
 
     /**
      * @psalm-suppress PossiblyUnusedReturnValue
+     *
+     * @param positive-int $id
      */
     public function setId(int $id): self;
 

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -11,6 +11,7 @@ use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Pag
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Reply;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Status;
 use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Entities\Posts\Topic;
+use Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities\TypesUtilities;
 use Symfony\Component\DomCrawler\Crawler;
 
 final class BrowserActions
@@ -145,11 +146,13 @@ final class BrowserActions
     }
 
     /**
+     * @return non-falsy-string
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
     private static function getSamplePermalink(Crawler $crawler): string
     {
-        return $crawler->filterXPath('//body//*[contains(@id, "edit-slug-box")]//a')->attr('href') ?? throw new \RuntimeException();
+        return TypesUtilities::getNonFalsyString($crawler->filterXPath('//body//*[contains(@id, "edit-slug-box")]//a')->attr('href'));
     }
 }

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -51,7 +51,7 @@ final class BrowserActions
 
         // XPath for a form element with all required fields: //form[input[(@id="_wpnonce" or @name="_wpnonce") and @type="hidden"]]
 
-        $post->setId((int) $postID->attr('value'));
+        $post->setId($postID);
         $post->setAuthorId($userID);
 
         $browser->request(
@@ -66,7 +66,7 @@ final class BrowserActions
                 'post_type' => $postType->attr('value'),
                 'original_post_status' => $originalPostStatus->attr('value'),
                 'referredby' => $referredBy->attr('value'),
-                'post_ID' => $postID->attr('value'),
+                'post_ID' => $postID,
                 'post_title' => $post->getTitle(),
                 'content' => $post->getContent(),
                 'post_status' => $post->getStatus()->value, // 'draft'
@@ -85,7 +85,7 @@ final class BrowserActions
 
         $form = $crawler->filterXPath('//body//div[@id="wpbody"]//input[@id="publish"]')->form();
 
-        $post->setId((int) self::getPostId($crawler)->attr('value'));
+        $post->setId(self::getPostId($crawler));
         $post->setAuthorId(self::getUserId($crawler));
 
         $formData = [
@@ -124,10 +124,16 @@ final class BrowserActions
         return $browser->request('GET', '/wp-admin/post-new.php?post_type='.$post->getType()->value);
     }
 
-    private static function getPostId(Crawler $crawler): Crawler
+    /**
+     * @return positive-int
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    private static function getPostId(Crawler $crawler): int
     {
         // In WordPress 5.9.3 "//form/input//[...] doesn't work. Probably because some markup are invalid.
-        return $crawler->filterXPath('//input[(@id="post_ID" or @name="post_ID") and @type="hidden"]');
+        return TypesUtilities::getPositiveInt($crawler->filterXPath('//input[(@id="post_ID" or @name="post_ID") and @type="hidden"]')->attr('value'));
     }
 
     /**

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -37,17 +37,17 @@ final class BrowserActions
     {
         $crawler = self::requestPostNewPage($browser, $post);
 
-        $nonce = $crawler->filterXPath('//form//input[(@id="_wpnonce" or @name="_wpnonce") and @type="hidden"]');
+        $nonce = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="_wpnonce" or @name="_wpnonce") and @type="hidden"]')->attr('value'));
 
         // In WordPress 5.9.3 "//form/input//[...] doesn't work. Probably because some markup are invalid.
         $postID = self::getPostId($crawler);
 
-        $postType = $crawler->filterXPath('//form//input[(@id="post_type" or @name="post_type") and @type="hidden"]');
-        $action = $crawler->filterXPath('//form//input[(@id="hiddenaction" or @name="action") and @type="hidden"]');
-        $originalAction = $crawler->filterXPath('//form//input[(@id="originalaction" or @name="originalaction") and @type="hidden"]');
+        $postType = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="post_type" or @name="post_type") and @type="hidden"]')->attr('value'));
+        $action = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="hiddenaction" or @name="action") and @type="hidden"]')->attr('value'));
+        $originalAction = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="originalaction" or @name="originalaction") and @type="hidden"]')->attr('value'));
         $userID = self::getUserId($crawler);
-        $originalPostStatus = $crawler->filterXPath('//form//input[(@id="original_post_status" or @name="original_post_status") and @type="hidden"]');
-        $referredBy = $crawler->filterXPath('//form//input[(@id="referredby" or @name="referredby") and @type="hidden"]');
+        $originalPostStatus = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="original_post_status" or @name="original_post_status") and @type="hidden"]')->attr('value'));
+        $referredBy = TypesUtilities::getNonFalsyString($crawler->filterXPath('//form//input[(@id="referredby" or @name="referredby") and @type="hidden"]')->attr('value'));
 
         // XPath for a form element with all required fields: //form[input[(@id="_wpnonce" or @name="_wpnonce") and @type="hidden"]]
 
@@ -58,14 +58,14 @@ final class BrowserActions
             'POST',
             '/wp-admin/post.php',
             [
-                '_wpnonce' => $nonce->attr('value'),
+                '_wpnonce' => $nonce,
                 '_wp_http_referer' => '/wp-admin/post-new.php?post_type='.$post->getType()->value,
-                'action' => $action->attr('value'),
-                'originalaction' => $originalAction->attr('value'),
+                'action' => $action,
+                'originalaction' => $originalAction,
                 'post_author' => $userID,
-                'post_type' => $postType->attr('value'),
-                'original_post_status' => $originalPostStatus->attr('value'),
-                'referredby' => $referredBy->attr('value'),
+                'post_type' => $postType,
+                'original_post_status' => $originalPostStatus,
+                'referredby' => $referredBy,
                 'post_ID' => $postID,
                 'post_title' => $post->getTitle(),
                 'content' => $post->getContent(),

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -31,6 +31,7 @@ final class BrowserActions
 
     /**
      * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     private static function createNativePostTypes(HttpBrowser $browser, Page $post): void
     {
@@ -51,7 +52,7 @@ final class BrowserActions
         // XPath for a form element with all required fields: //form[input[(@id="_wpnonce" or @name="_wpnonce") and @type="hidden"]]
 
         $post->setId((int) $postID->attr('value'));
-        $post->setAuthorId((int) $userID->attr('value'));
+        $post->setAuthorId($userID);
 
         $browser->request(
             'POST',
@@ -61,7 +62,7 @@ final class BrowserActions
                 '_wp_http_referer' => '/wp-admin/post-new.php?post_type='.$post->getType()->value,
                 'action' => $action->attr('value'),
                 'originalaction' => $originalAction->attr('value'),
-                'post_author' => $userID->attr('value'),
+                'post_author' => $userID,
                 'post_type' => $postType->attr('value'),
                 'original_post_status' => $originalPostStatus->attr('value'),
                 'referredby' => $referredBy->attr('value'),
@@ -85,7 +86,7 @@ final class BrowserActions
         $form = $crawler->filterXPath('//body//div[@id="wpbody"]//input[@id="publish"]')->form();
 
         $post->setId((int) self::getPostId($crawler)->attr('value'));
-        $post->setAuthorId((int) self::getUserId($crawler)->attr('value'));
+        $post->setAuthorId(self::getUserId($crawler));
 
         $formData = [
             'post_title' => $post->getTitle(),
@@ -129,9 +130,15 @@ final class BrowserActions
         return $crawler->filterXPath('//input[(@id="post_ID" or @name="post_ID") and @type="hidden"]');
     }
 
-    private static function getUserId(Crawler $crawler): Crawler
+    /**
+     * @return positive-int
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    private static function getUserId(Crawler $crawler): int
     {
-        return $crawler->filterXPath('//form//input[(@id="user-id" or @name="user_ID") and @type="hidden"]');
+        return TypesUtilities::getPositiveInt($crawler->filterXPath('//form//input[(@id="user-id" or @name="user_ID") and @type="hidden"]')->attr('value'));
     }
 
     /**

--- a/.github/tests/application/tests/Services/BrowserActions.php
+++ b/.github/tests/application/tests/Services/BrowserActions.php
@@ -150,6 +150,6 @@ final class BrowserActions
      */
     private static function getSamplePermalink(Crawler $crawler): string
     {
-        return $crawler->filterXPath('//body//*[contains(@id, "sample-permalink")]//a')->attr('href') ?? throw new \RuntimeException();
+        return $crawler->filterXPath('//body//*[contains(@id, "edit-slug-box")]//a')->attr('href') ?? throw new \RuntimeException();
     }
 }

--- a/.github/tests/application/tests/Utilities/TypesUtilities.php
+++ b/.github/tests/application/tests/Utilities/TypesUtilities.php
@@ -29,10 +29,15 @@ final class TypesUtilities
      */
     public static function getPositiveInt(?string $value): int
     {
-        $value = (int) trim($value ?? throw new \RuntimeException());
+        $value = trim($value ?? throw new \RuntimeException());
+        $validated = filter_var(
+            $value,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]]
+        );
 
-        if ($value > 0) {
-            return $value;
+        if (false !== $validated) {
+            return $validated;
         }
 
         throw new \RuntimeException();

--- a/.github/tests/application/tests/Utilities/TypesUtilities.php
+++ b/.github/tests/application/tests/Utilities/TypesUtilities.php
@@ -21,4 +21,20 @@ final class TypesUtilities
 
         throw new \RuntimeException();
     }
+
+    /**
+     * @return positive-int
+     *
+     * @throws \RuntimeException
+     */
+    public static function getPositiveInt(?string $value): int
+    {
+        $value = (int) trim($value ?? throw new \RuntimeException());
+
+        if ($value > 0) {
+            return $value;
+        }
+
+        throw new \RuntimeException();
+    }
 }

--- a/.github/tests/application/tests/Utilities/TypesUtilities.php
+++ b/.github/tests/application/tests/Utilities/TypesUtilities.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Korobochkin\BBPressPermalinksWithIdTestsApplication\Tests\Utilities;
+
+final class TypesUtilities
+{
+    /**
+     * @return non-falsy-string
+     *
+     * @throws \RuntimeException
+     */
+    public static function getNonFalsyString(?string $value): string
+    {
+        $value = trim($value ?? throw new \RuntimeException());
+
+        if ($value) {
+            return $value;
+        }
+
+        throw new \RuntimeException();
+    }
+}


### PR DESCRIPTION
Added extra checks in the code that fetch values from HTML attributes to prevent usage of invalid data. It is not 100% safe validation (because there is no goal and sense to check all WordPress generated HTML) but it is more than enough to ensure that HTML elements were found correctly and that we get a value (not an empty string).

The xPath for finding a sample permalink on wp-admin page was updated. As I noticed the HTML markup is different for different kind of entities (Page, Post, Forum, Topic, Reply).