### PR TITLE
Application Tests. Native function invocation

### DIFF
--- a/.github/tests/application/Makefile
+++ b/.github/tests/application/Makefile
@@ -34,7 +34,7 @@ run_tests_from_host:
 	docker exec php make run_tests
 
 php_cs_fixer:
-	vendor/bin/php-cs-fixer fix --config=php-cs-fixer.php --cache-file=.cache/.php-cs-fixer.cache --format=txt --no-interaction
+	vendor/bin/php-cs-fixer fix --config=php-cs-fixer.php --cache-file=.cache/.php-cs-fixer.cache --format=txt --no-interaction --allow-risky=yes
 
 .PHONY: \
 	build \

--- a/.github/tests/application/php-cs-fixer.php
+++ b/.github/tests/application/php-cs-fixer.php
@@ -11,6 +11,8 @@ $finder = new Finder()
 
 return new Config()
     ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
         '@PhpCsFixer' => true,
         'fully_qualified_strict_types' => [
             'import_symbols' => true,

--- a/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
+++ b/.github/tests/application/tests/Abstracts/AbstractHttpTestCase.php
@@ -70,7 +70,7 @@ abstract class AbstractHttpTestCase extends TestCase
             );
 
             $this->fail(
-                'WordPress server produced '.count($newErrors)." error(s) during this test:\n"
+                'WordPress server produced '.\count($newErrors)." error(s) during this test:\n"
                 .implode("\n", $messages),
             );
         }
@@ -148,7 +148,7 @@ abstract class AbstractHttpTestCase extends TestCase
             $noticesOnPage[] = trim($node->textContent);
         }
 
-        $this->assertStringContainsStringIgnoringCase($needle, implode(PHP_EOL, $noticesOnPage));
+        $this->assertStringContainsStringIgnoringCase($needle, implode(\PHP_EOL, $noticesOnPage));
     }
 
     /**

--- a/.github/tests/application/tests/DataProviders/ForumDataProvider.php
+++ b/.github/tests/application/tests/DataProviders/ForumDataProvider.php
@@ -254,7 +254,7 @@ final class ForumDataProvider
     private function topicsPagedGenerator(): \Generator
     {
         foreach ($this->data as $i => [$forum, $topicsAndReplies]) {
-            $topicsCounter = count($topicsAndReplies);
+            $topicsCounter = \count($topicsAndReplies);
 
             if ($topicsCounter > $this->topicsPerPage) {
                 $numberOfPages = (int) ceil($topicsCounter / $this->topicsPerPage);
@@ -270,9 +270,9 @@ final class ForumDataProvider
                         $offset = 0;
                     }
 
-                    $slice = array_slice($topicsAndReplies, $offset, $length);
+                    $slice = \array_slice($topicsAndReplies, $offset, $length);
 
-                    $topicsOnPage = array_map(function ($topicAndReplies) {
+                    $topicsOnPage = array_map(static function ($topicAndReplies) {
                         return $topicAndReplies[0];
                     }, $slice);
 
@@ -305,7 +305,7 @@ final class ForumDataProvider
         $i = 0;
         foreach ($this->data as [$forum, $topicsAndReplies]) {
             foreach ($topicsAndReplies as [$topic, $replies]) {
-                $repliesCounter = count($replies) + 1; // + 1 is a topic itself
+                $repliesCounter = \count($replies) + 1; // + 1 is a topic itself
 
                 if ($repliesCounter > $this->repliesPerPage) {
                     $numberOfPages = (int) ceil($repliesCounter / $this->repliesPerPage);
@@ -314,7 +314,7 @@ final class ForumDataProvider
                     for ($page = 1; $page <= $numberOfPages; ++$page) {
                         $length = 1 === $page ? $this->repliesPerPage - 1 : $this->repliesPerPage;
 
-                        $slice = array_slice($replies, $offset, $length);
+                        $slice = \array_slice($replies, $offset, $length);
 
                         $offset += $length;
 

--- a/.github/tests/application/tests/Services/BrowsersService.php
+++ b/.github/tests/application/tests/Services/BrowsersService.php
@@ -65,7 +65,7 @@ final class BrowsersService
     {
         if (
             isset($_ENV[$name->value])
-            && is_string($_ENV[$name->value])
+            && \is_string($_ENV[$name->value])
             && '' !== $_ENV[$name->value]
         ) {
             return $_ENV[$name->value];
@@ -91,7 +91,7 @@ final class BrowsersService
 
         $response = $browser->getResponse();
 
-        if (200 !== $response->getStatusCode() || false !== strpos($response->getContent(), 'login_error')) {
+        if (200 !== $response->getStatusCode() || str_contains($response->getContent(), 'login_error')) {
             throw new \RuntimeException('Failed to login');
         }
     }

--- a/.github/tests/application/tests/Services/WordPressServerLogs.php
+++ b/.github/tests/application/tests/Services/WordPressServerLogs.php
@@ -43,7 +43,7 @@ final class WordPressServerLogs
      */
     public function checkpoint(): void
     {
-        $this->errorCheckpoint = count($this->getErrors());
+        $this->errorCheckpoint = \count($this->getErrors());
     }
 
     /**
@@ -53,7 +53,7 @@ final class WordPressServerLogs
      */
     public function getErrorsSinceCheckpoint(): array
     {
-        return array_slice($this->getErrors(), $this->errorCheckpoint);
+        return \array_slice($this->getErrors(), $this->errorCheckpoint);
     }
 
     /**
@@ -67,10 +67,10 @@ final class WordPressServerLogs
             return [];
         }
 
-        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $lines = file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES);
 
         if (false === $lines) {
-            throw new \UnexpectedValueException(sprintf('Failed to read log file "%s".', $path));
+            throw new \UnexpectedValueException(\sprintf('Failed to read log file "%s".', $path));
         }
 
         $entries = [];
@@ -89,7 +89,7 @@ final class WordPressServerLogs
     {
         $data = json_decode($line, true);
 
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw new \UnexpectedValueException('Invalid $data object');
         }
 

--- a/.github/tests/application/tests/Utilities/Random.php
+++ b/.github/tests/application/tests/Utilities/Random.php
@@ -13,7 +13,7 @@ final class Random
      */
     public static function positiveInteger(): int
     {
-        return random_int(1, PHP_INT_MAX);
+        return random_int(1, \PHP_INT_MAX);
     }
 
     /**

--- a/.github/tests/application/tests/Utilities/TypesUtilities.php
+++ b/.github/tests/application/tests/Utilities/TypesUtilities.php
@@ -32,7 +32,7 @@ final class TypesUtilities
         $value = trim($value ?? throw new \RuntimeException());
         $validated = filter_var(
             $value,
-            FILTER_VALIDATE_INT,
+            \FILTER_VALIDATE_INT,
             ['options' => ['min_range' => 1]]
         );
 


### PR DESCRIPTION
Added a few rule sets to the `.github/tests/application/php-cs-fixer.php`. The `@Symfony:risky` has [`native_function_invocation`](https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html) rule that adds `\` for PHP native functions to speed up resolving.