### PR TITLE
Application Tests. PHP update 8.4 -> 8.5

### DIFF
--- a/tests/application/composer.json
+++ b/tests/application/composer.json
@@ -20,5 +20,8 @@
         "symfony/http-client": "^8.0",
         "symfony/mime": "^8.0",
         "friendsofphp/php-cs-fixer": "^3.95"
+    },
+    "require": {
+        "php": "^8.5"
     }
 }

--- a/tests/application/composer.lock
+++ b/tests/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48c8c8c18aa34b980a0bf39a5b5e0c89",
+    "content-hash": "c852133064a105a0f778f21b51b82d86",
     "packages": [],
     "packages-dev": [
         {
@@ -5013,7 +5013,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^8.5"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/tests/application/containers/php/php.Dockerfile
+++ b/tests/application/containers/php/php.Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.4-cli-bookworm
+FROM php:8.5-cli-bookworm
 
-COPY --from=composer/composer:2.8-bin /composer /usr/bin/composer
+COPY --from=composer/composer:2.9-bin /composer /usr/bin/composer
 
 RUN apt update --quiet --assume-yes \
     && apt install unzip --quiet --assume-yes --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
Update PHP 8.4 -> 8.5 for container that runs application tests. The version is locked with `composer.json`.