### PR TITLE
Application Tests. Container improvements

### DIFF
--- a/.github/workflows/tests-application.yml
+++ b/.github/workflows/tests-application.yml
@@ -82,19 +82,11 @@ jobs:
 
     - name: Docker Compose Build
       working-directory: tests/application
-      run: make build
+      run: make build-php
 
-    - name: Docker Compose Up
+    - name: Docker Compose Up PHP
       working-directory: tests/application
-      run: make up
-
-    - name: Composer Install
-      working-directory: tests/application
-      run: make composer_install_from_host
-
-    - name: Run Application Tests
-      working-directory: tests/application
-      run: make run_tests_from_host
+      run: make up-php
 
     - name: Docker Compose Down
       working-directory: tests/application

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ALL
     security_opt:
       - no-new-privileges=true
+    read_only: true
     init: true
     tty: true
     volumes:

--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -30,6 +30,8 @@ reset_logs:
 vendor: composer.json composer.lock
 	whoami;
 	ls -alh;
+	chmod -R a+w .
+	ls -alh
 	@if [ ! -d vendor ]; then \
 		mkdir vendor; \
 	fi

--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -30,8 +30,6 @@ reset_logs:
 vendor: composer.json composer.lock
 	whoami;
 	ls -alh;
-	chmod -R a+w .
-	ls -alh
 	@if [ ! -d vendor ]; then \
 		mkdir vendor; \
 	fi

--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -8,10 +8,30 @@ build-php:
 	docker compose build --quiet --with-dependencies php
 
 up:
-	docker compose up --detach --no-build --quiet-pull --remove-orphans --timeout=120 --wait-timeout=120 --wait --yes
+	docker compose up \
+		--detach \
+		--no-build \
+		--quiet-pull \
+		--remove-orphans \
+		--timeout=120 \
+		--wait-timeout=120 \
+		--wait \
+		--yes \
+		php-develop
 
 up-php:
-	docker compose up --no-build --quiet-pull --remove-orphans --timeout=120 --wait-timeout=120 --yes --abort-on-container-failure --attach php
+	docker compose up \
+		--no-build \
+		--quiet-pull \
+		--remove-orphans \
+		--timeout=120 \
+		--wait-timeout=120 \
+		--yes \
+		--abort-on-container-failure \
+		--no-log-prefix \
+		--exit-code-from=php \
+		--attach=php \
+		php
 
 stop:
 	docker compose stop

--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -2,10 +2,16 @@
 CONTAINER_NAME_PREFIX := bbpress-permalinks-with-id-application-tests
 
 build:
-	docker compose build --quiet
+	docker compose build
+
+build-php:
+	docker compose build --quiet --with-dependencies php
 
 up:
 	docker compose up --detach --no-build --quiet-pull --remove-orphans --timeout=120 --wait-timeout=120 --wait --yes
+
+up-php:
+	docker compose up --no-build --quiet-pull --remove-orphans --timeout=120 --wait-timeout=120 --yes --abort-on-container-failure --attach php
 
 stop:
 	docker compose stop
@@ -28,33 +34,22 @@ reset_logs:
 	docker exec "$(CONTAINER_NAME_PREFIX)-syslog-1" sh -c "find /var/log/remote -maxdepth 1 -type f -name '*.log' -exec truncate -s 0 {} \;"
 
 vendor: composer.json composer.lock
-	whoami;
-	ls -alh;
-	@if [ ! -d vendor ]; then \
-		mkdir vendor; \
-	fi
 	composer install --no-scripts --no-interaction --no-progress --classmap-authoritative
-
-composer_install_from_host:
-	docker exec "$(CONTAINER_NAME_PREFIX)-php-1" make vendor
 
 run_tests:
 	 vendor/bin/phpunit --no-progress --testsuite=default
-
-run_tests_from_host:
-	docker exec "$(CONTAINER_NAME_PREFIX)-php-1" make run_tests
 
 php_cs_fixer:
 	vendor/bin/php-cs-fixer fix --config=php-cs-fixer.php --cache-file=.cache/.php-cs-fixer.cache --format=txt --no-interaction --allow-risky=yes
 
 .PHONY: \
 	build \
+	build-php \
 	up \
+	up-php \
 	stop \
 	down \
 	config \
 	reset_logs \
-	composer_install_from_host \
 	run_tests \
-	run_tests_from_host \
 	php_cs_fixer

--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -28,6 +28,11 @@ reset_logs:
 	docker exec "$(CONTAINER_NAME_PREFIX)-syslog-1" sh -c "find /var/log/remote -maxdepth 1 -type f -name '*.log' -exec truncate -s 0 {} \;"
 
 vendor: composer.json composer.lock
+	whoami;
+	ls -alh;
+	@if [ ! -d vendor ]; then \
+		mkdir vendor; \
+	fi
 	composer install --no-scripts --no-interaction --no-progress --classmap-authoritative
 
 composer_install_from_host:

--- a/tests/application/containers/php/php.Dockerfile
+++ b/tests/application/containers/php/php.Dockerfile
@@ -1,9 +1,28 @@
-FROM php:8.5-cli-bookworm
+FROM php:8.5-cli-bookworm AS base
 
 COPY --from=composer/composer:2.9-bin /composer /usr/bin/composer
 
-RUN apt update --quiet --assume-yes \
-    && apt install unzip --quiet --assume-yes --no-install-recommends --no-install-suggests \
-    && pecl install xdebug
+RUN apt-get update --quiet --assume-yes \
+    && apt-get install --quiet --assume-yes --no-install-recommends --no-install-suggests unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/tests-application
+
+FROM base AS dependencies
+
+RUN \
+    --mount=type=bind,source=composer.json,destination=./composer.json \
+    --mount=type=bind,source=composer.lock,destination=./composer.lock \
+    --mount=type=bind,source=Makefile,destination=./Makefile \
+    --mount=type=cache,id=composer,destination=/root/.composer \
+    make vendor
+
+FROM php:8.5-cli-bookworm AS tests-runner
+
+WORKDIR /root/tests-application
+
+COPY --from=dependencies /root/tests-application/vendor /root/tests-application
+
+FROM base AS develop
+
+RUN pecl install xdebug

--- a/tests/application/containers/php/php.Dockerfile
+++ b/tests/application/containers/php/php.Dockerfile
@@ -22,6 +22,8 @@ FROM php:8.5-cli-bookworm AS tests-runner
 
 WORKDIR /root/tests-application
 
+ENTRYPOINT ["make", "run_tests"]
+
 COPY --from=dependencies /root/tests-application/vendor /root/tests-application/vendor
 
 FROM base AS develop

--- a/tests/application/containers/php/php.Dockerfile
+++ b/tests/application/containers/php/php.Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /root/tests-application
 FROM base AS dependencies
 
 RUN \
+    --mount=type=bind,source=tests,destination=./tests \
     --mount=type=bind,source=composer.json,destination=./composer.json \
     --mount=type=bind,source=composer.lock,destination=./composer.lock \
     --mount=type=bind,source=Makefile,destination=./Makefile \
@@ -21,7 +22,7 @@ FROM php:8.5-cli-bookworm AS tests-runner
 
 WORKDIR /root/tests-application
 
-COPY --from=dependencies /root/tests-application/vendor /root/tests-application
+COPY --from=dependencies /root/tests-application/vendor /root/tests-application/vendor
 
 FROM base AS develop
 

--- a/tests/application/containers/wordpress/.htaccess
+++ b/tests/application/containers/wordpress/.htaccess
@@ -1,0 +1,15 @@
+# BEGIN WordPress
+# The directives (lines) between "BEGIN WordPress" and "END WordPress" are
+# dynamically generated, and should only be modified via WordPress filters.
+# Any changes to the directives between these markers will be overwritten.
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+
+# END WordPress

--- a/tests/application/containers/wordpress/wordpress.Dockerfile
+++ b/tests/application/containers/wordpress/wordpress.Dockerfile
@@ -26,7 +26,11 @@ EXPOSE 8080/tcp
 
 RUN rm -rf /usr/src/wordpress/wp-content/plugins/* \
     && rm -rf /usr/src/wordpress/wp-content/themes/* \
-    && rm /usr/src/php*
+    && rm /usr/src/php* \
+    && cp --recursive /usr/src/wordpress/* /var/www/html/ \
+    && mv /var/www/html/wp-config-docker.php /var/www/html/wp-config.php \
+    && chown --recursive www-data:www-data /var/www/html \
+    && rm -rf /usr/src/wordpress
 
 RUN sed --in-place 's/\*:80>/\*:8080>/g' /etc/apache2/sites-available/* \
 	&& \
@@ -34,6 +38,8 @@ RUN sed --in-place 's/\*:80>/\*:8080>/g' /etc/apache2/sites-available/* \
     && \
     sed --in-place 's/#ServerName www\.example\.com/ServerName one\.wordpress\.test/g' /etc/apache2/sites-available/*.conf
 
-COPY --chown=www-data:www-data ./mu-plugins /usr/src/wordpress/wp-content/mu-plugins
-COPY --from=plugins --chown=www-data:www-data /tmp/plugins /usr/src/wordpress/wp-content/plugins/
-COPY --from=themes --chown=www-data:www-data /tmp/themes /usr/src/wordpress/wp-content/themes/
+COPY --chown=www-data:www-data ./mu-plugins /var/www/html/wp-content/mu-plugins
+COPY --from=plugins --chown=www-data:www-data /tmp/plugins /var/www/html/wp-content/plugins/
+COPY --from=themes --chown=www-data:www-data /tmp/themes /var/www/html/wp-content/themes/
+
+ENTRYPOINT ["apache2-foreground"]

--- a/tests/application/containers/wordpress/wordpress.Dockerfile
+++ b/tests/application/containers/wordpress/wordpress.Dockerfile
@@ -38,6 +38,7 @@ RUN sed --in-place 's/\*:80>/\*:8080>/g' /etc/apache2/sites-available/* \
     && \
     sed --in-place 's/#ServerName www\.example\.com/ServerName one\.wordpress\.test/g' /etc/apache2/sites-available/*.conf
 
+COPY --chown=www-data:www-data .htaccess /var/www/html
 COPY --chown=www-data:www-data ./mu-plugins /var/www/html/wp-content/mu-plugins
 COPY --from=plugins --chown=www-data:www-data /tmp/plugins /var/www/html/wp-content/plugins/
 COPY --from=themes --chown=www-data:www-data /tmp/themes /var/www/html/wp-content/themes/

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -164,7 +164,6 @@ services:
       - ./phpunit.xml:/root/tests-application/phpunit.xml:read-only
       - ./phpunit-bootstrap.php:/root/tests-application/phpunit-bootstrap.php:read-only
       - syslog_data:/var/log/remote:read-only
-    command: make run_tests
 
   php-develop:
     <<: *service-php

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     security_opt:
       - no-new-privileges=true
     read_only: true
+    user: 33:33
     networks:
       default:
         aliases:
@@ -77,9 +78,8 @@ services:
         define( 'AUTOMATIC_UPDATER_DISABLED', true );
         define( 'WP_POST_REVISIONS', false );
     tmpfs:
-      - /var/run/apache2
-      - /tmp
-      - /var
+      - /run:mode=770,uid=33,gid=33
+      - /tmp:mode=770,uid=33,gid=33
     volumes:
       - ../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id:read-only
     logging:
@@ -122,7 +122,8 @@ services:
       retries: 3
     tmpfs:
       - /tmp
-      - /var/run/mysqld
+      - /run
+      - /run/mysqld
     volumes:
       - db_data:/var/lib/mysql
 

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -53,6 +53,8 @@ services:
         define( 'WP_AUTO_UPDATE_CORE', false );
         define( 'AUTOMATIC_UPDATER_DISABLED', true );
         define( 'WP_POST_REVISIONS', false );
+    tmpfs:
+      - /var/run/apache2
     volumes:
       - wordpress_data:/var/www/html
       - ../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -121,9 +121,8 @@ services:
       timeout: 5s
       retries: 3
     tmpfs:
-      - /tmp
-      - /run
-      - /run/mysqld
+      - /tmp:mode=770,uid=10001,gid=10001
+      - /run:mode=770,uid=10001,gid=10001
     volumes:
       - db_data:/var/lib/mysql
 

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     security_opt:
       - no-new-privileges=true
     read_only: true
+    user: 10001:10001
     environment:
       MYSQL_DATABASE: "${MYSQL_DATABASE}"
       MYSQL_USER: "${MYSQL_USER}"
@@ -93,6 +94,9 @@ services:
       start_interval: 10s
       timeout: 5s
       retries: 3
+    tmpfs:
+      - /tmp
+      - /var/run/mysqld
     volumes:
       - db_data:/var/lib/mysql
 

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     build:
       context: ./containers/syslog
       dockerfile: ./syslog.Dockerfile
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
     volumes:
       - syslog_data:/var/log/remote
     ports:
@@ -24,6 +29,11 @@ services:
         WORDPRESS_ARG_BASE_IMAGE: "${WORDPRESS_ARG_BASE_IMAGE}"
         WORDPRESS_ARG_PLUGIN_BBPRESS_ZIP_URL: "${WORDPRESS_ARG_PLUGIN_BBPRESS_ZIP_URL}"
         WORDPRESS_ARG_THEME_ZIP_URL: "${WORDPRESS_ARG_THEME_ZIP_URL}"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
     networks:
       default:
         aliases:
@@ -65,6 +75,11 @@ services:
 
   db:
     image: mysql:8.0
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
     environment:
       MYSQL_DATABASE: "${MYSQL_DATABASE}"
       MYSQL_USER: "${MYSQL_USER}"
@@ -83,6 +98,11 @@ services:
 
   cli:
     image: "${CLI_ARG_BASE_IMAGE}"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_NAME: "${MYSQL_DATABASE}"
@@ -108,6 +128,11 @@ services:
   php:
     build:
       dockerfile: ./containers/php/php.Dockerfile
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
     tty: true
     init: true
     volumes:

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -143,7 +143,10 @@ services:
     read_only: true
     tty: true
     init: true
+    tmpfs:
+      - /tmp
     volumes:
+      - ./.cache/composer:/root/.composer
       - ./:/root/tests-application
       - ./containers/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
       - syslog_data:/var/log/remote:ro

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -159,7 +159,10 @@ services:
   php:
     <<: *service-php
     volumes:
-      - ./:/root/tests-application:read-only
+      - ./tests:/root/tests-application/tests:read-only
+      - ./Makefile:/root/tests-application/Makefile:read-only
+      - ./phpunit.xml:/root/tests-application/phpunit.xml:read-only
+      - ./phpunit-bootstrap.php:/root/tests-application/phpunit-bootstrap.php:read-only
       - syslog_data:/var/log/remote:read-only
     command: make run_tests
 

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       - /tmp
     volumes:
       - ./.cache/composer:/root/.composer
-      - ./:/root/tests-application
+      - ./../application:/root/tests-application
       - ./containers/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
       - syslog_data:/var/log/remote:ro
     ports:

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -147,7 +147,7 @@ services:
     volumes_from:
       - wordpress
     volumes:
-      - ./containers/cli/shells/:/tmp/shells/:ro
+      - ./containers/cli/shells/:/tmp/shells/:read-only
     depends_on:
       wordpress:
         condition: service_healthy

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -55,6 +55,8 @@ services:
         define( 'WP_POST_REVISIONS', false );
     tmpfs:
       - /var/run/apache2
+      - /tmp
+      - /var
     volumes:
       - wordpress_data:/var/www/html
       - ../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -81,8 +81,7 @@ services:
       - /tmp
       - /var
     volumes:
-      - wordpress_data:/var/www/html
-      - ../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id
+      - ../../:/var/www/html/wp-content/plugins/bbpress-permalinks-with-id:read-only
     logging:
       driver: syslog
       options:
@@ -94,7 +93,7 @@ services:
       syslog:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "http://${WORDPRESS_DOMAIN}:8080/index.php/wp-json/"]
+      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "http://${WORDPRESS_DOMAIN}:8080/wp-json/"]
       start_period: 2s
       start_interval: 5s
       timeout: 5s
@@ -191,5 +190,4 @@ volumes:
       type: tmpfs
       device: tmpfs
       o: size=10m
-  wordpress_data:
   db_data:

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       syslog:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://${WORDPRESS_DOMAIN}:8080/index.php/wp-json/"]
+      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "http://${WORDPRESS_DOMAIN}:8080/index.php/wp-json/"]
       start_period: 2s
       start_interval: 5s
       timeout: 5s

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -159,6 +159,7 @@ services:
   php:
     <<: *service-php
     volumes:
+      - ./.cache:/root/tests-application/.cache
       - ./tests:/root/tests-application/tests:read-only
       - ./Makefile:/root/tests-application/Makefile:read-only
       - ./phpunit.xml:/root/tests-application/phpunit.xml:read-only

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -1,4 +1,27 @@
 ---
+
+x-php-build: &service-php-build
+  dockerfile: ./containers/php/php.Dockerfile
+  target: tests-runner
+
+x-php: &service-php
+  build:
+    <<: *service-php-build
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges=true
+  read_only: true
+  environment:
+    WORDPRESS_SITE_HOME: "http://${WORDPRESS_DOMAIN}:8080"
+    WORDPRESS_ADMIN_LOGIN: "${WORDPRESS_ADMIN_LOGIN}"
+    WORDPRESS_ADMIN_PASSWORD: "${WORDPRESS_ADMIN_PASSWORD}"
+  depends_on:
+    wordpress:
+      condition: service_healthy
+    cli:
+      condition: service_completed_successfully
+
 name: bbpress-permalinks-with-id-application-tests
 services:
   syslog:
@@ -134,31 +157,28 @@ services:
     command: [ "bash", "/tmp/shells/install-wordpress.sh" ]
 
   php:
+    <<: *service-php
+    volumes:
+      - ./:/root/tests-application:read-only
+      - syslog_data:/var/log/remote:read-only
+    command: make run_tests
+
+  php-develop:
+    <<: *service-php
     build:
-      dockerfile: ./containers/php/php.Dockerfile
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges=true
-    read_only: true
+      <<: *service-php-build
+      target: develop
     tty: true
     init: true
+    ports:
+      - '127.0.0.1:9009:9009'
     tmpfs:
       - /tmp
     volumes:
       - ./.cache/composer:/root/.composer
-      - ./../application:/root/tests-application
-      - ./containers/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
-      - syslog_data:/var/log/remote:ro
-    ports:
-      - '127.0.0.1:9009:9009'
-    environment:
-      WORDPRESS_SITE_HOME: "http://${WORDPRESS_DOMAIN}:8080"
-      WORDPRESS_ADMIN_LOGIN: "${WORDPRESS_ADMIN_LOGIN}"
-      WORDPRESS_ADMIN_PASSWORD: "${WORDPRESS_ADMIN_PASSWORD}"
-    depends_on:
-      wordpress:
-        condition: service_healthy
+      - ./:/root/tests-application
+      - ./containers/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini:read-only
+      - syslog_data:/var/log/remote:read-only
 
 volumes:
   syslog_data:

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -69,9 +69,9 @@ services:
       syslog:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "test", "-f", "/var/www/html/wp-config.php"]
-      start_period: 5s
-      start_interval: 10s
+      test: ["CMD", "curl", "--fail", "http://${WORDPRESS_DOMAIN}:8080/index.php/wp-json/"]
+      start_period: 2s
+      start_interval: 5s
       timeout: 5s
       retries: 3
 

--- a/tests/application/phpunit.xml
+++ b/tests/application/phpunit.xml
@@ -10,7 +10,10 @@
          displayDetailsOnPhpunitDeprecations="true"
          failOnPhpunitDeprecation="true"
          failOnRisky="true"
-         failOnWarning="true">
+         failOnWarning="true"
+         stopOnError="true"
+         stopOnFailure="true"
+>
     <testsuites>
         <testsuite name="default">
             <directory>tests/TestCases</directory>

--- a/tests/application/phpunit.xml
+++ b/tests/application/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="phpunit-bootstrap.php"
          cacheDirectory=".cache/phpunit"
+         cacheResult="false"
          executionOrder="depends,defects"
          requireCoverageMetadata="true"
          beStrictAboutCoverageMetadata="true"


### PR DESCRIPTION
Updated and improved the whole container's layout that is used for Application Tests.

- Added security-related settings to all containers (`tests/application/docker-compose.yml`).
  - `cap_drop: [ALL]`
  - `security_opt: [no-new-privileges=true]`
  - `read_only: true`
- Improved the dependency tree in the `tests/application/docker-compose.yml`. Now the `cli` container simply waits for `wordpress`, runs commands and exits. The `php` container waits for cli's `condition: service_completed_successfully`. This allowed simplify the health checks of containers as well.
- Split the PHP container into 2 different services.
  1. For CI usage. Runs tests and exits.
  2. For local usage and development. It includes Xdebug and allows to run any commands.
- The `tests/application/containers/php/php.Dockerfile` for the PHP container has been updated so it is possible to build different images.
- The `tests/application/containers/wordpress/wordpress.Dockerfile` was updated so it does not do any file modifications (as https://hub.docker.com/_/wordpress always does). Modifying files in a container is a bad practice (I do not know why the "official" WordPress image is so bad).
- Added `failOnWarning="true"`, `stopOnError="true"`, `stopOnFailure="true"` to the `tests/application/phpunit.xml` to exit early. No sense in running the whole test suite if something goes wrong at the beginning of these tests.