### PR TITLE
Minor improvements for syslog container

### DIFF
--- a/tests/application/containers/syslog/syslog.Dockerfile
+++ b/tests/application/containers/syslog/syslog.Dockerfile
@@ -2,8 +2,12 @@ FROM alpine:latest
 
 SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
 
-RUN mkdir -p /var/log/remote && \
-    apk --no-cache add rsyslog net-tools
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --progress=no \
+    && apk upgrade --progress=no \
+    && apk add --progress=no rsyslog net-tools \
+    && mkdir -p /var/log/remote
 
 EXPOSE 1514/udp
 

--- a/tests/application/containers/syslog/syslog.Dockerfile
+++ b/tests/application/containers/syslog/syslog.Dockerfile
@@ -9,6 +9,15 @@ RUN \
     && apk add --progress=no rsyslog net-tools \
     && mkdir -p /var/log/remote
 
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID syslog \
+   && adduser -u $UID -G syslog -D -s /bin/sh syslog
+
+USER $UID:$GID
+
 EXPOSE 1514/udp
 
 CMD ["rsyslogd", "-n", "-f", "/etc/rsyslog.conf"]

--- a/tests/application/containers/syslog/syslog.Dockerfile
+++ b/tests/application/containers/syslog/syslog.Dockerfile
@@ -20,4 +20,4 @@ USER $UID:$GID
 
 EXPOSE 1514/udp
 
-CMD ["rsyslogd", "-n", "-f", "/etc/rsyslog.conf"]
+ENTRYPOINT ["rsyslogd", "-n", "-f", "/etc/rsyslog.conf"]

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -58,6 +58,9 @@ services:
     build:
       context: ./containers/syslog
       dockerfile: ./syslog.Dockerfile
+      args:
+        UID: 1001
+        GID: 1001
     cap_drop:
       - ALL
     security_opt:
@@ -67,8 +70,8 @@ services:
       - source: syslog_main
         target: /etc/rsyslog.conf
         mode: 0400
-        uid: '0'
-        gid: '0'
+        uid: '1001'
+        gid: '1001'
     volumes:
       - syslog_data:/var/log/remote
     ports:


### PR DESCRIPTION
Added minor improvements for syslog container. Use a regular user instead of root. Add cache for the `/var/cache/apk` - it is not kept in the image but preserved between builds (currently this works only with local builds and does not work in CI).