### PR TITLE
Application Tests. DB version and healthcheck

### DIFF
--- a/tests/application/Makefile
+++ b/tests/application/Makefile
@@ -32,8 +32,8 @@ up-php:
 		--no-build \
 		--quiet-pull \
 		--remove-orphans \
-		--timeout=120 \
-		--wait-timeout=120 \
+		--timeout=240 \
+		--wait-timeout=240 \
 		--yes \
 		--abort-on-container-failure \
 		--no-log-prefix \

--- a/tests/application/docker-compose.yml
+++ b/tests/application/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       retries: 3
 
   db:
-    image: mysql:9.7.1
+    image: mysql:9.7.2
     cap_drop:
       - ALL
     security_opt:
@@ -161,9 +161,9 @@ services:
       - '127.0.0.1:3306:3306'
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "--host=127.0.0.1", "--user=$$MYSQL_USER", "--password=$$MYSQL_PASSWORD" ]
-      start_period: 5s
-      start_interval: 10s
-      timeout: 5s
+      start_period: 15s
+      start_interval: 15s
+      timeout: 10s
       retries: 3
     tmpfs:
       - /tmp:mode=770,uid=10001,gid=10001


### PR DESCRIPTION
- Updated container boot up timeouts from 120 to 240s.
- Updated `mysql:9.7.1` -> `mysql:9.7.2`.
- Extended health check grace period.