### PR TITLE
Rewrite `php-syntax-check` for using containers instead of action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   php-syntax-check:
-    name: 'PHP ${{ matrix.php-versions }} Syntax Check'
+    name: PHP Syntax ${{ matrix.php-versions }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,16 +34,27 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up the PHP
-        uses: shivammathur/setup-php@v2
+      - name: Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
         with:
-          extensions: none
-          tools: none
-          ini-file: development
-          php-version: ${{ matrix.php-versions }}
+          cleanup: true
 
-      - name: Run PHP Syntax Check
-        run: make php-syntax-check
+      - name: Docker Bake
+        uses: docker/bake-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          files: development/docker-compose-tests.yml
+          targets: php-syntax-check-php-${{ matrix.php-versions }}
+
+      - name: Docker Compose Up. PHP Syntax Check
+        working-directory: development
+        run: make up-php-syntax-check-php-${{ matrix.php-versions }}
+
+      - name: Docker Compose Down
+        if: always()
+        working-directory: development
+        run: make down
 
   php-syntax-check-tests-application:
     name: 'PHP Syntax Check. Tests. Application'

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ php-syntax-check:
 	| \
 	xargs --null --verbose --max-procs=4 --max-args=1 php --syntax-check
 
+php-syntax-check-busybox:
+	find . \
+	\( -path "./.github" -o -path "./development" -o -path "./tests/application" \) -prune \
+	-o -type f -name "*.php" -print0 \
+	| \
+	xargs -0 -t -P 4 -n 1 php --syntax-check
+
 php-syntax-check-tests-application:
 	find tests/application \
 	\( -path "tests/application/.cache" -o -path "tests/application/vendor" \) -prune \
@@ -74,4 +81,5 @@ php-syntax-check-tests-application:
 	phpmd \
 	plugin-check \
 	php-syntax-check \
+	php-syntax-check-busybox \
 	php-syntax-check-tests-application

--- a/development/Makefile
+++ b/development/Makefile
@@ -1,0 +1,52 @@
+
+build:
+	docker compose --file docker-compose-tests.yml build
+
+_up-%:
+	docker compose \
+		--file=docker-compose-tests.yml \
+		up \
+		--no-build \
+		--quiet-pull \
+		--remove-orphans \
+		--timeout=120 \
+		--wait-timeout=120 \
+		--yes \
+		--abort-on-container-failure \
+		--no-log-prefix \
+		--exit-code-from=$* \
+		--attach=$* \
+		$*
+
+up-php-syntax-check-php-5.6: _up-php-syntax-check-php-5.6
+
+up-php-syntax-check-php-7.4: _up-php-syntax-check-php-7.4
+
+up-php-syntax-check-php-8.0: _up-php-syntax-check-php-8.0
+
+up-php-syntax-check-php-8.1: _up-php-syntax-check-php-8.1
+
+up-php-syntax-check-php-8.2: _up-php-syntax-check-php-8.2
+
+up-php-syntax-check-php-8.3: _up-php-syntax-check-php-8.3
+
+up-php-syntax-check-php-8.4: _up-php-syntax-check-php-8.4
+
+stop:
+	docker compose --file=docker-compose-tests.yml stop
+
+down:
+	docker compose --file=docker-compose-tests.yml down --remove-orphans --volumes
+
+.PHONY: \
+	build \
+	_up-% \
+	up-php-syntax-check-php-5.6 \
+	up-php-syntax-check-php-7.4 \
+	up-php-syntax-check-php-8.0 \
+	up-php-syntax-check-php-8.1 \
+	up-php-syntax-check-php-8.2 \
+	up-php-syntax-check-php-8.3 \
+	up-php-syntax-check-php-8.4 \
+	stop \
+	down

--- a/development/containers/php/php-5.6.Dockerfile
+++ b/development/containers/php/php-5.6.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:5.6-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-7.4.Dockerfile
+++ b/development/containers/php/php-7.4.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:7.4-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-8.0.Dockerfile
+++ b/development/containers/php/php-8.0.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.0-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-8.1.Dockerfile
+++ b/development/containers/php/php-8.1.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.1-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-8.2.Dockerfile
+++ b/development/containers/php/php-8.2.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.2-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-8.3.Dockerfile
+++ b/development/containers/php/php-8.3.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.3-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/containers/php/php-8.4.Dockerfile
+++ b/development/containers/php/php-8.4.Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.4.5-cli-alpine AS php-base
+
+SHELL ["/bin/sh", "-euo", "pipefail", "-c"]
+
+RUN \
+   mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk update --no-progress \
+    && apk upgrade --no-progress \
+    && apk add --no-progress make
+
+ARG UID
+ARG GID
+
+RUN \
+   addgroup -g $GID php \
+   && adduser -u $UID -G php -D -s /bin/sh php
+
+USER $UID:$GID
+
+WORKDIR /home/php/app

--- a/development/docker-compose-tests.yml
+++ b/development/docker-compose-tests.yml
@@ -1,0 +1,86 @@
+---
+x-php-base: &service-php-base
+  build: &service-php-base-build
+    context: ../
+    dockerfile: ./development/containers/php/php-8.4.Dockerfile
+    target: php-base
+    args:
+      UID: 1001
+      GID: 1001
+    x-bake:
+      output:
+        - type=docker
+    cache_from:
+      - type=gha
+    cache_to:
+      - type=gha,mode=max
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges=true
+  read_only: true
+  user: 1001:1001
+  entrypoint: ["make", "php-syntax-check-busybox"]
+  volumes:
+    - ../:/home/php/app:read-only
+  tmpfs:
+    - /tmp
+    - /run
+
+name: bbpress-permalinks-with-id-tests
+services:
+  php-syntax-check-php-5.6:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-5.6.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-5.6:latest
+
+  php-syntax-check-php-7.4:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-7.4.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-7.4:latest
+
+  php-syntax-check-php-8.0:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.0.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.0:latest
+
+  php-syntax-check-php-8.1:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.1.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.1:latest
+
+  php-syntax-check-php-8.2:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.2.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.2:latest
+
+  php-syntax-check-php-8.3:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.3.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.3:latest
+
+  php-syntax-check-php-8.4:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.4.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.4:latest


### PR DESCRIPTION
Updated the `.github/workflows/tests.yml` and `jobs.php-syntax-check`. Now it uses custom PHP alpine based containers instead of `shivammathur/setup-php@v2` action. This adds more control and security. New `Dockerfile`s can be reused for other jobs in the future.