### PR TITLE
Rewrite `php-syntax-check-tests-application` for using containers instead of action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: make down
 
   php-syntax-check-tests-application:
-    name: 'PHP Syntax Check. Tests. Application'
+    name: PHP Syntax. Tests. Application
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,16 +69,27 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up the PHP
-        uses: shivammathur/setup-php@v2
+      - name: Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
         with:
-          extensions: none
-          tools: none
-          ini-file: development
-          php-version: 8.4
+          cleanup: true
 
-      - name: Run PHP Syntax Check
-        run: make php-syntax-check-tests-application
+      - name: Docker Bake
+        uses: docker/bake-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          files: development/docker-compose-tests.yml
+          targets: php-syntax-check-tests-application
+
+      - name: Docker Compose Up. PHP Syntax Check
+        working-directory: development
+        run: make up-php-syntax-check-tests-application
+
+      - name: Docker Compose Down
+        if: always()
+        working-directory: development
+        run: make down
 
   phpcs:
     name: 'PHP Coding Standards and Compatibility'

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ php-syntax-check-tests-application:
 	| \
 	xargs --null --verbose --max-procs=4 --max-args=1 php --syntax-check
 
+php-syntax-check-tests-application-busybox:
+	find tests/application \
+	\( -path "tests/application/.cache" -o -path "tests/application/vendor" \) -prune \
+	-o -type f -name "*.php" -print0 \
+	| \
+	xargs -0 -t -P 4 -n 1 php --syntax-check
+
 .PHONY: \
 	build \
 	up \

--- a/Makefile
+++ b/Makefile
@@ -89,4 +89,5 @@ php-syntax-check-tests-application-busybox:
 	plugin-check \
 	php-syntax-check \
 	php-syntax-check-busybox \
-	php-syntax-check-tests-application
+	php-syntax-check-tests-application \
+	php-syntax-check-tests-application-busybox

--- a/development/Makefile
+++ b/development/Makefile
@@ -34,6 +34,8 @@ up-php-syntax-check-php-8.4: _up-php-syntax-check-php-8.4
 
 up-php-syntax-check-php-8.5: _up-php-syntax-check-php-8.5
 
+up-php-syntax-check-tests-application: _up-php-syntax-check-tests-application
+
 stop:
 	docker compose --file=docker-compose-tests.yml stop
 
@@ -51,5 +53,6 @@ down:
 	up-php-syntax-check-php-8.3 \
 	up-php-syntax-check-php-8.4 \
 	up-php-syntax-check-php-8.5 \
+	up-php-syntax-check-tests-application \
 	stop \
 	down

--- a/development/docker-compose-tests.yml
+++ b/development/docker-compose-tests.yml
@@ -92,3 +92,12 @@ services:
       dockerfile: ./development/containers/php/php-8.5.Dockerfile
       tags:
         - bbpress-permalinks-with-id-tests-php-syntax-check-php-8.5:latest
+
+  php-syntax-check-tests-application:
+    <<: *service-php-base
+    build:
+      <<: *service-php-base-build
+      dockerfile: ./development/containers/php/php-8.5.Dockerfile
+      tags:
+        - bbpress-permalinks-with-id-tests-php-syntax-check-tests-application:latest
+    entrypoint: [ "make", "php-syntax-check-tests-application-busybox" ]

--- a/development/docker-compose-tests.yml
+++ b/development/docker-compose-tests.yml
@@ -100,4 +100,4 @@ services:
       dockerfile: ./development/containers/php/php-8.5.Dockerfile
       tags:
         - bbpress-permalinks-with-id-tests-php-syntax-check-tests-application:latest
-    entrypoint: [ "make", "php-syntax-check-tests-application-busybox" ]
+    entrypoint: ["make", "php-syntax-check-tests-application-busybox"]


### PR DESCRIPTION
As it was done in the https://github.com/korobochkin/bbpress-permalinks-with-id/pull/153, this PR changes `php-syntax-check-tests-application` job in `.github/workflows/tests.yml` for using container with PHP instead of `shivammathur/setup-php@v2` action.